### PR TITLE
Jenkinsfile - Updated execute release and deploy on the main branch.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,14 +32,14 @@ node {
         }
     }
 
-    onlyOnMaster {
+    onlyOnMain {
         stage("release") {
             releaseApp(image: img)
         }
     }
 }
 
-onlyOnMaster {
+onlyOnMain {
     milestone()
     stage("qa deploy") {
         deployApp(image: img, app: "checkmate", env: "qa")


### PR DESCRIPTION
Jenkinsfile update -  Changes the branch we are looking to invoke `release` and `deployment` stages against. Required because GitHub have altered the name of their default branch from `master` to `main`. 