### PR TITLE
Add curl which is required for downloading the blocklist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6.9-alpine3.10
 LABEL maintainer="Hypothes.is Project and contributors"
 
 # Install nginx & supervisor
-RUN apk add --no-cache nginx gettext supervisor
+RUN apk add --no-cache nginx gettext supervisor curl
 
 # Create the hypothesis user, group, home directory and package directory.
 RUN addgroup -S hypothesis && adduser -S -G hypothesis -h /var/lib/hypothesis hypothesis


### PR DESCRIPTION
https://github.com/hypothesis/checkmate/pull/16 requires `curl` to pull down the list.