### PR TITLE
Make the install instructions shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,28 +89,18 @@ Installing Checkmate in a development environment
 
 ### You will need
 
-* [Git](https://git-scm.com/)
-
 * [pyenv](https://github.com/pyenv/pyenv)
   Follow the instructions in the pyenv README to install it.
   The Homebrew method works best on macOS.
   
-### Clone the git repo
+### Clone the git repo and `cd` into the directory
 
     git clone https://github.com/hypothesis/checkmate.git
-
-This will download the code into a `checkmate` directory in your current working
-directory. You need to be in the `checkmate` directory from the remainder of the
-installation process:
-
     cd checkmate
 
 ### Start the development server
 
     make dev
-
-The first time you run `make dev` it might take a while to start because it'll
-need to install the application dependencies and build the assets.
 
 This will start the app on http://localhost:9099
 


### PR DESCRIPTION
* Don't list `git` as a requirement: it should be obvious enough that this is needed
* Merge the `git clone` and `cd` commands into a single code block, no need to explain why the `cd` is necessary
* Don't tell people that `make dev` will take a while the first time. Someone requested that I add this because they felt that people would be confused because `make dev` and take a short while to start the app the first time you run it. Personally I don't think it's necessary to say this

I don't see anything else to cut out of these: they tell you to install one necessary prerequisite and to run three commands, then they give you a localhost link to the app's port, tell you that you're done, and point you to `make help` for more.