### PR TITLE
Integrate with URLHaus for more active threat detection

### DIFF
--- a/checkmate/views/api/check_url.py
+++ b/checkmate/views/api/check_url.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 from pyramid.httpexceptions import HTTPNoContent
 from pyramid.view import view_config
 
-from checkmate.checker.url.custom_rules import CustomRules
+from checkmate.checker.url import CustomRules, URLHaus
 from checkmate.exceptions import BadURLParameter
 from checkmate.url import hash_url
 
@@ -21,13 +21,8 @@ def check_url(request):
     url_hashes = list(hash_url(url))
 
     # Use a set to weed out repeated identifications
-    reasons = set()
-
-    # Update with reasons from our private list table
-    reasons.update(CustomRules(request.db).check_url(url_hashes))
-
-    # Update with reasons from other services?
-    ...
+    reasons = set(CustomRules(request.db).check_url(url_hashes))
+    reasons.update(URLHaus(request.db).check_url(url_hashes))
 
     if not reasons:
         # If everything is fine give a 204 which is successful, but has no body

--- a/tests/unit/checkmate/views/api/check_url_test.py
+++ b/tests/unit/checkmate/views/api/check_url_test.py
@@ -7,18 +7,29 @@ from checkmate.views.api.check_url import check_url
 
 
 class TestURLCheck:
-    def test_a_good_url(self, make_request):
+    def test_a_good_url(self, make_request, CustomRules, URLHaus):
         request = make_request("/api/check", {"url": "http://happy.example.com"})
 
-        result = check_url(request)
+        response = check_url(request)
 
-        assert result.status_code == 204
+        assert response.status_code == 204
 
-    def test_a_bad_url(self, make_request, CustomRules):
-        CustomRules.return_value.check_url.return_value = (
-            Reason.MEDIA_IMAGE,
-            Reason.MALICIOUS,
+        CustomRules.assert_called_once_with(request.db)
+        custom_rules = CustomRules.return_value
+        custom_rules.check_url.assert_called_once_with(
+            list(hash_url("http://happy.example.com"))
         )
+
+        URLHaus.assert_called_once_with(request.db)
+        url_haus = CustomRules.return_value
+        url_haus.check_url.assert_called_once_with(
+            list(hash_url("http://happy.example.com"))
+        )
+
+    def test_a_bad_url(self, make_request, CustomRules, URLHaus):
+        CustomRules.return_value.check_url.return_value = (Reason.MEDIA_IMAGE,)
+        URLHaus.return_value.check_url.return_value = (Reason.MALICIOUS,)
+
         request = make_request("/api/check", {"url": "http://sad.example.com"})
 
         result = check_url(request)
@@ -34,12 +45,6 @@ class TestURLCheck:
             },
         }
 
-        CustomRules.assert_called_once_with(request.db)
-        custom_rules = CustomRules.return_value
-        custom_rules.check_url.assert_called_once_with(
-            list(hash_url("http://sad.example.com"))
-        )
-
     def test_it_returns_an_error_for_no_url(self, make_request):
         request = make_request("/api/check")
 
@@ -49,5 +54,11 @@ class TestURLCheck:
     @pytest.fixture(autouse=True)
     def CustomRules(self, patch):
         CustomRules = patch("checkmate.views.api.check_url.CustomRules")
+        CustomRules.return_value.check_url.return_value = tuple()
+        return CustomRules
+
+    @pytest.fixture(autouse=True)
+    def URLHaus(self, patch):
+        CustomRules = patch("checkmate.views.api.check_url.URLHaus")
         CustomRules.return_value.check_url.return_value = tuple()
         return CustomRules

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -48,26 +48,26 @@ def pyramid_config(pyramid_settings):
 
 
 @pytest.fixture
-def pyramid_request(pyramid_config, db_engine):
-    return _make_request("/dummy", pyramid_config, db_engine)
+def pyramid_request(pyramid_config, db_session):
+    return _make_request("/dummy", pyramid_config, db_session)
 
 
 @pytest.fixture
-def make_request(pyramid_config, db_engine):
+def make_request(pyramid_config, db_session):
     def make_request(path="/irrelevant", params=None):
         if params:  # pragma: no cover
             path += "?" + urlencode(params)
 
-        return _make_request(path, pyramid_config, db_engine)
+        return _make_request(path, pyramid_config, db_session)
 
     return make_request
 
 
-def _make_request(path, pyramid_config, db_engine):
+def _make_request(path, pyramid_config, db_session):
     pyramid_request = Request.blank(path)
     pyramid_request.registry = pyramid_config.registry
     pyramid_request.tm = MagicMock()
-    pyramid_request.db = db_engine
+    pyramid_request.db = db_session
 
     return pyramid_request
 


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/37

This enables the URLHaus checker as part of the actual end-point return information. It also provides tasks for calling and updating it.

### Testing notes

You can kick off the async tasks with:

```python
from checkmate.async.tasks import initialise_urlhaus, sync_urlhaus

initialise_urlhaus.delay()
sync_urlhaus.delay()
```

You should then be able to get hits for URLs listed by the service like this:

 * Run: `make dev`
 * http://localhost:9099/api/check?url=http://42.225.203.47/i
