### PR TITLE
Catch invalid URLs without domains as a special case

### DIFF
--- a/checkmate/checker/url/blocklist.py
+++ b/checkmate/checker/url/blocklist.py
@@ -7,6 +7,7 @@ from logging import getLogger
 from urllib.parse import urlparse
 
 from checkmate.checker.url.reason import Reason
+from checkmate.exceptions import MalformedURL
 
 
 class Blocklist:
@@ -37,11 +38,15 @@ class Blocklist:
         """Test the URL and return a list of reasons it should be blocked.
 
         :param url: URL to test
+        :raise MalformedURL: If the URL cannot be parsed
         :return: An iterable of Reason objects (which may be empty)
         """
         self._refresh()
 
         domain = self._domain(url)
+        if not domain:
+            raise MalformedURL(f"The URL: '{url}' has no domain to check")
+
         blocked = self.domains.get(domain)
         if blocked:
             yield blocked

--- a/checkmate/exceptions.py
+++ b/checkmate/exceptions.py
@@ -33,3 +33,7 @@ class BadURLParameter(JSONAPIException):
         data["source"] = {"parameter": self.param}
 
         return data
+
+
+class MalformedURL(Exception):
+    """The URL is malformed in some way."""

--- a/checkmate/views/api/check_url.py
+++ b/checkmate/views/api/check_url.py
@@ -5,7 +5,7 @@ from pyramid.httpexceptions import HTTPNoContent
 from pyramid.view import view_config
 
 from checkmate.checker.url.blocklist import Blocklist
-from checkmate.exceptions import BadURLParameter
+from checkmate.exceptions import BadURLParameter, MalformedURL
 
 
 @view_config(route_name="check_url", renderer="json")
@@ -21,7 +21,10 @@ def check_url(request):
     reasons = set()
 
     # Update with reasons from our private list
-    reasons.update(request.registry.url_blocklist.check_url(url))
+    try:
+        reasons.update(request.registry.url_blocklist.check_url(url))
+    except MalformedURL as err:
+        raise BadURLParameter("url", err.args[0]) from err
 
     # Update with reasons from other services?
     ...

--- a/tests/unit/checkmate/checker/url/blocklist_test.py
+++ b/tests/unit/checkmate/checker/url/blocklist_test.py
@@ -5,6 +5,7 @@ from h_matchers import Any
 
 from checkmate.checker.url.blocklist import Blocklist
 from checkmate.checker.url.reason import Reason
+from checkmate.exceptions import MalformedURL
 
 
 class TestBlocklist:
@@ -110,6 +111,13 @@ class TestBlocklist:
         blocklist.add_domain("*.example.net", Reason.OTHER)
 
         assert blocklist.check_url(url) == Any.generator.containing(reasons).only()
+
+    @pytest.mark.parametrize("url", ("http://", "http:///", "http:///foo", "/"))
+    def test_it_raises_MalformedURL_for_bad_urls(self, url):
+        blocklist = Blocklist("missing.txt")
+
+        with pytest.raises(MalformedURL):
+            tuple(blocklist.check_url(url))
 
     @pytest.fixture
     def blocklist_file(self, tmp_path):

--- a/tests/unit/checkmate/views/api/check_url_test.py
+++ b/tests/unit/checkmate/views/api/check_url_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from checkmate.checker.url.blocklist import Blocklist
 from checkmate.checker.url.reason import Reason
-from checkmate.exceptions import BadURLParameter
+from checkmate.exceptions import BadURLParameter, MalformedURL
 from checkmate.views.api.check_url import check_url
 
 
@@ -35,6 +35,15 @@ class TestURLCheck:
 
     def test_it_returns_an_error_for_no_url(self, make_request):
         request = make_request("/api/check")
+
+        with pytest.raises(BadURLParameter):
+            check_url(request)
+
+    def test_it_returns_an_error_if_blocklist_raises_MalformedURL(
+        self, make_request, blocklist
+    ):
+        request = make_request("/api/check?url=http://")
+        blocklist.check_url.side_effect = MalformedURL("URL is bad")
 
         with pytest.raises(BadURLParameter):
             check_url(request)


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/27

We will return a 400 instead of 500. We should also do work to prevent these from getting this far upstream.