### PR TITLE
Add Google Web Risk hashing, expansion and normalisation functions

### DIFF
--- a/checkmate/url/__init__.py
+++ b/checkmate/url/__init__.py
@@ -1,0 +1,7 @@
+"""An implementation of Google Web Risk normalisation routines.
+
+For more details see: https://cloud.google.com/web-risk/docs/urls-hashing
+"""
+
+from checkmate.url.canonicalize import CanonicalURL
+from checkmate.url.expand import ExpandURL

--- a/checkmate/url/canonicalize.py
+++ b/checkmate/url/canonicalize.py
@@ -1,0 +1,177 @@
+"""An implementation of Google Web Risk URL canonicalization.
+
+As defined here: https://cloud.google.com/web-risk/docs/urls-hashing#canonicalization
+"""
+
+import os.path
+import re
+from urllib.parse import unquote, urlparse, urlunparse
+
+from netaddr import AddrFormatError, IPAddress
+
+
+class CanonicalURL:
+    """Implementation of Google Web Risk URL canonicalization."""
+
+    @classmethod
+    def canonicalize(cls, url):
+        """Convert a URL to a canonical form for comparison.
+
+        This may "invent" a scheme as necessary.
+
+        :param url: URL to normalise
+        :return: A normalised version of the URL
+        """
+        scheme, netloc, path, params, query = cls._pre_process_url(url)
+
+        netloc = cls._canonicalize_host(netloc)
+        path = cls._canonicalize_path(path)
+
+        # In the URL, percent-escape all characters that are <= ASCII 32, >=
+        # 127, #, or %. The escapes should use uppercase hex characters.
+        netloc = cls._partial_quote(netloc)
+        path = cls._partial_quote(path)
+
+        clean_url = urlunparse([scheme, netloc, path, params, query, None])
+
+        # Get around the fact that URL parse strips off the '?' if the query
+        # string is empty
+        if url.endswith("?") and not clean_url.endswith("?"):
+            clean_url += "?"
+
+        return clean_url
+
+    BANNED_CHARS = re.compile("[\x09\x0d\x0a]")
+
+    @classmethod
+    def _pre_process_url(cls, url):
+        # https://cloud.google.com/web-risk/docs/urls-hashing#canonicalization
+
+        clean_url = url.strip()
+
+        # First, remove tab (0x09), CR (0x0d), and LF (0x0a) characters from
+        # the URL. Do not remove escape sequences for these characters,
+        # like %0a.
+
+        clean_url = cls.BANNED_CHARS.sub("", clean_url)
+
+        # Second, if the URL ends in a fragment, remove the fragment. For
+        # example, shorten http://google.com/#frag to http://google.com/.
+
+        scheme, netloc, path, params, query, _fragment = urlparse(clean_url)
+
+        if not scheme and not netloc:
+            # Without a scheme urlparse goes totally crazy, so add a default
+            # and try again
+            return cls._pre_process_url("http://" + url)
+
+        # Third, repeatedly remove percent-escapes from the URL until it has
+        # no more percent-escapes.
+
+        netloc = cls._repeated_unquote(netloc)
+        path = cls._repeated_unquote(path)
+
+        return scheme, netloc, path, params, query
+
+    CONSECUTIVE_DOTS = re.compile(r"\.\.+")
+    PORT = re.compile(r":\d+$")
+
+    @classmethod
+    def _canonicalize_host(cls, hostname):
+        # https://cloud.google.com/web-risk/docs/urls-hashing#to_canonicalize_the_hostname
+
+        # If the URL uses an internationalized domain name (IDN), the client
+        # should convert the URL to the ASCII Punycode representation.
+        try:
+            # https://docs.python.org/3/library/codecs.html#module-encodings.idna
+            hostname = hostname.encode("idna").decode("ascii")
+        except UnicodeError:
+            # Oh well
+            pass
+
+        # 1. Remove all leading and trailing dots.
+        hostname = hostname.strip(".")
+
+        # 2. Replace consecutive dots with a single dot.
+        hostname = cls.CONSECUTIVE_DOTS.sub(".", hostname)
+
+        # Not in the text, but in the test cases
+        hostname = cls.PORT.sub("", hostname)
+
+        # 3. If the hostname can be parsed as an IP address, normalize it to 4
+        # dot-separated decimal values. The client should handle any legal
+        # IP-address encoding, including octal, hex, and fewer than
+        # four components.
+        ip_address = cls._decode_ip(hostname)
+        if ip_address:
+            hostname = ip_address
+
+        # 4. Lowercase the whole string.
+        hostname = hostname.lower()
+
+        return hostname
+
+    CONSECUTIVE_SLASHES = re.compile("//+")
+
+    @classmethod
+    def _canonicalize_path(cls, path):
+        # https://cloud.google.com/web-risk/docs/urls-hashing#to_canonicalize_the_path
+
+        # 1. Resolve the sequences /../ and /./ in the path by replacing
+        # /./ with /, and removing /../ along with the preceding path
+        # component.
+        if path:
+            path = os.path.normpath(path) + ("/" if path.endswith("/") else "")
+
+        # 2. Replace runs of consecutive slashes with a single slash character.
+        path = cls.CONSECUTIVE_SLASHES.sub("/", path)
+
+        return path or "/"
+
+    HEX_DOT_IP = re.compile(r"^[0-f]+\.[0-f]+\.[0-f]+\.[0-f]+$", re.IGNORECASE)
+    BINARY_DOT_IP = re.compile(r"^[01]+\.[01]+\.[01]+\.[01]+$", re.IGNORECASE)
+
+    @classmethod
+    def _decode_ip(cls, hostname):
+        """Try and spot hostnames that are really encoded IP addresses."""
+        if cls.HEX_DOT_IP.match(hostname):
+            decoded = cls._decode_ip("0x" + hostname.replace(".", ""))
+
+            if decoded:
+                return decoded
+
+        if cls.BINARY_DOT_IP.match(hostname):
+            parts = [str(int(part, 2)) for part in hostname.split(".")]
+            return ".".join(parts)
+
+        try:
+            return str(IPAddress(hostname))
+        except AddrFormatError:
+            return None
+
+    @classmethod
+    def _repeated_unquote(cls, string):
+        decoded = unquote(string)
+
+        # Keep decoding until the string stops changing
+        while decoded != string:
+            string = decoded
+            decoded = unquote(string)
+
+        return decoded
+
+    @classmethod
+    def _partial_quote(cls, string):
+        parts = []
+        for char in string:
+            char_code = ord(char)
+
+            # In the URL, percent-escape all characters that are <= ASCII 32,
+            # >= 127, #, or %. The escapes should use uppercase hex characters.
+            if char_code <= 32 or char_code >= 127 or char in "#%":
+                parts.append("%{:02X}".format(char_code))
+            else:
+                parts.append(char)
+
+        final = "".join(parts)
+        return final

--- a/checkmate/url/expand.py
+++ b/checkmate/url/expand.py
@@ -1,0 +1,73 @@
+"""An implementation of Google Web Risk suffix/prefix expressions."""
+import re
+from urllib.parse import urlparse
+
+
+class ExpandURL:
+    """Expand a URL into variations for comparison.
+
+    As defined in: https://cloud.google.com/web-risk/docs/urls-hashing#suffixprefix_expressions
+    """
+
+    IPV4 = re.compile(r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}")
+
+    @classmethod
+    def expand(cls, normalised_url):
+        """Expand a URL into many versions for comparison.
+
+        This will:
+
+         * Remove the scheme and "://"
+         * Progressively remove parts from the start of the domain
+         * Progressively simplify the path
+
+        :param normalised_url: A pre-normalised URL to vary
+        :returns: A generator of domain suffix, path prefix variations
+        """
+        parsed = urlparse(normalised_url)
+
+        path_variants = tuple(cls._vary_path(parsed.path, parsed.query))
+
+        for host in cls._vary_hostname(parsed.netloc):
+            for path in path_variants:
+                yield host + path
+
+    @classmethod
+    def expand_single(cls, normalised_url):
+        """Create a single expansion of the URL.
+
+        This allows you to create the least simplified version of the
+        expansions to use to create rules for comparing with.
+        """
+        parsed = urlparse(normalised_url)
+
+        return normalised_url.replace(parsed.scheme + "://", "")
+
+    @classmethod
+    def _vary_hostname(cls, hostname):
+        yield hostname
+
+        # Don't snip of bits of a IP address thinking it's a domain name
+        if cls.IPV4.match(hostname):
+            return
+
+        # Progressively snip things from the left a maximum of 4 times,
+        # starting from something which has a maximum of 5 components even if
+        # the original domain has more
+        parts = hostname.split(".")
+        start = max(len(parts) - 5, 1)
+        for pos in range(start, len(parts) - 1):
+            yield ".".join(parts[pos:])
+
+    @classmethod
+    def _vary_path(cls, path, query):
+        if query:
+            yield path + "?" + query
+
+        yield path
+
+        # Build the path up from the start a maximum of 4 times
+        parts = path.rstrip("/").split("/")
+        max_parts = min(len(parts), 5)
+        for pos in range(1, max_parts):
+            yield "/".join(parts[:pos]) + "/"

--- a/checkmate/url/hash.py
+++ b/checkmate/url/hash.py
@@ -1,0 +1,37 @@
+"""Implementation of Google Web Risk URL hashing.
+
+As defined here: https://cloud.google.com/web-risk/docs/urls-hashing#hash_computations
+"""
+
+from hashlib import sha256
+
+from checkmate.url.canonicalize import CanonicalURL
+from checkmate.url.expand import ExpandURL
+
+# This is all very speculation based at this point, we're not sure how this
+# is going to look until we have our hands on some data.
+
+
+def hash_url(url, num_bytes=None):  # pragma: no cover
+    """Create multiple hashed variations of a URL to check."""
+
+    if num_bytes is None:
+        num_bytes = 32
+
+    url = CanonicalURL.canonicalize(url)
+
+    for variant in ExpandURL.expand(url):
+        digest = sha256(variant.encode("ascii"))
+
+        yield digest.digest()[:num_bytes]
+
+
+def hash_for_rule(url):  # pragma: no cover
+    """Create a full hash of a URL for to compare against."""
+
+    url = CanonicalURL.canonicalize(url)
+    url = ExpandURL.expand_single(url)
+
+    digest = sha256(url.encode("ascii"))
+
+    return digest.digest()

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,6 +23,7 @@ h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt
 hupper==1.10.2            # via -r requirements/requirements.txt, pyramid
 idna==2.10                # via -r requirements/requirements.txt, requests
 importlib-metadata==2.0.0  # via jsonschema
+importlib-resources==3.3.0  # via -r requirements/requirements.txt, netaddr
 ipdb==0.13.4              # via -r requirements/dev.in
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.16.1           # via -r requirements/dev.in, ipdb
@@ -30,6 +31,7 @@ jedi==0.17.2              # via ipython
 jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
 jsonschema==3.2.0         # via docker-compose
 markupsafe==1.1.1         # via -r requirements/requirements.txt, jinja2, pyramid-jinja2
+netaddr==0.8.0            # via -r requirements/requirements.txt
 newrelic==5.22.1.152      # via -r requirements/requirements.txt
 paramiko==2.7.2           # via docker
 parso==0.7.1              # via jedi
@@ -60,7 +62,7 @@ venusian==3.0.0           # via -r requirements/requirements.txt, pyramid
 wcwidth==0.2.5            # via prompt-toolkit
 webob==1.8.6              # via -r requirements/requirements.txt, pyramid
 websocket-client==0.57.0  # via docker, docker-compose
-zipp==3.4.0               # via importlib-metadata
+zipp==3.4.0               # via -r requirements/requirements.txt, importlib-metadata, importlib-resources
 zope.deprecation==4.4.0   # via -r requirements/requirements.txt, pyramid, pyramid-jinja2
 zope.interface==5.2.0     # via -r requirements/requirements.txt, pyramid
 

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -20,12 +20,14 @@ httpretty==1.0.2          # via -r requirements/tests.txt
 hupper==1.10.2            # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid
 idna==2.10                # via -r requirements/requirements.txt, -r requirements/tests.txt, requests
 importlib-metadata==2.0.0  # via -r requirements/tests.txt, pluggy, pytest
+importlib-resources==3.3.0  # via -r requirements/requirements.txt, -r requirements/tests.txt, netaddr
 iniconfig==1.1.1          # via -r requirements/tests.txt, pytest
 isort==5.6.4              # via pylint
 jinja2==2.11.2            # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid-jinja2
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/requirements.txt, -r requirements/tests.txt, jinja2, pyramid-jinja2
 mccabe==0.6.1             # via pylint
+netaddr==0.8.0            # via -r requirements/requirements.txt, -r requirements/tests.txt
 newrelic==5.22.1.152      # via -r requirements/requirements.txt, -r requirements/tests.txt
 packaging==20.4           # via -r requirements/tests.txt, pytest
 pastedeploy==2.1.1        # via -r requirements/requirements.txt, -r requirements/tests.txt, plaster-pastedeploy
@@ -57,7 +59,7 @@ waitress==1.4.4           # via -r requirements/tests.txt, webtest
 webob==1.8.6              # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid, webtest
 webtest==2.0.35           # via -r requirements/tests.txt
 wrapt==1.12.1             # via astroid
-zipp==3.4.0               # via -r requirements/tests.txt, importlib-metadata
+zipp==3.4.0               # via -r requirements/requirements.txt, -r requirements/tests.txt, importlib-metadata, importlib-resources
 zope.deprecation==4.4.0   # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid, pyramid-jinja2
 zope.interface==5.2.0     # via -r requirements/requirements.txt, -r requirements/tests.txt, pyramid
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,3 +4,4 @@ pyramid-jinja2
 requests
 newrelic
 h_pyramid_sentry
+netaddr

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,8 +10,10 @@ gunicorn==20.0.4          # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.1   # via -r requirements/requirements.in
 hupper==1.10.2            # via pyramid
 idna==2.10                # via requests
+importlib-resources==3.3.0  # via netaddr
 jinja2==2.11.2            # via pyramid-jinja2
 markupsafe==1.1.1         # via jinja2, pyramid-jinja2
+netaddr==0.8.0            # via -r requirements/requirements.in
 newrelic==5.22.1.152      # via -r requirements/requirements.in
 pastedeploy==2.1.1        # via plaster-pastedeploy
 plaster-pastedeploy==0.7  # via pyramid
@@ -24,6 +26,7 @@ translationstring==1.4    # via pyramid
 urllib3==1.26.1           # via requests, sentry-sdk
 venusian==3.0.0           # via pyramid
 webob==1.8.6              # via pyramid
+zipp==3.4.0               # via importlib-resources
 zope.deprecation==4.4.0   # via pyramid, pyramid-jinja2
 zope.interface==5.2.0     # via pyramid
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -18,9 +18,11 @@ httpretty==1.0.2          # via -r requirements/tests.in
 hupper==1.10.2            # via -r requirements/requirements.txt, pyramid
 idna==2.10                # via -r requirements/requirements.txt, requests
 importlib-metadata==2.0.0  # via pluggy, pytest
+importlib-resources==3.3.0  # via -r requirements/requirements.txt, netaddr
 iniconfig==1.1.1          # via pytest
 jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
 markupsafe==1.1.1         # via -r requirements/requirements.txt, jinja2, pyramid-jinja2
+netaddr==0.8.0            # via -r requirements/requirements.txt
 newrelic==5.22.1.152      # via -r requirements/requirements.txt
 packaging==20.4           # via pytest
 pastedeploy==2.1.1        # via -r requirements/requirements.txt, plaster-pastedeploy
@@ -45,7 +47,7 @@ venusian==3.0.0           # via -r requirements/requirements.txt, pyramid
 waitress==1.4.4           # via webtest
 webob==1.8.6              # via -r requirements/requirements.txt, pyramid, webtest
 webtest==2.0.35           # via -r requirements/tests.in
-zipp==3.4.0               # via importlib-metadata
+zipp==3.4.0               # via -r requirements/requirements.txt, importlib-metadata, importlib-resources
 zope.deprecation==4.4.0   # via -r requirements/requirements.txt, pyramid, pyramid-jinja2
 zope.interface==5.2.0     # via -r requirements/requirements.txt, pyramid
 

--- a/tests/unit/checkmate/url/canonicalise_test.py
+++ b/tests/unit/checkmate/url/canonicalise_test.py
@@ -1,0 +1,76 @@
+import pytest
+
+from checkmate.url.canonicalize import CanonicalURL
+
+
+class TestCanonicalURL:
+    # Taken from: https://cloud.google.com/web-risk/docs/urls-hashing#to_canonicalize_the_path
+    # With some extras of our own
+    @pytest.mark.parametrize(
+        "url,canonical_url",
+        (
+            ("http://host/%25%32%35", "http://host/%25"),
+            ("http://host/%25%32%35%25%32%35", "http://host/%25%25"),
+            ("http://host/%2525252525252525", "http://host/%25"),
+            ("http://host/asdf%25%32%35asd", "http://host/asdf%25asd"),
+            ("http://host/%%%25%32%35asd%%", "http://host/%25%25%25asd%25%25"),
+            ("http://www.google.com/", "http://www.google.com/"),
+            (
+                "http://%31%36%38%2e%31%38%38%2e%39%39%2e%32%36/%2E%73%65%63%75%72%65/%77%77%77%2E%65%62%61%79%2E%63%6F%6D/",
+                "http://168.188.99.26/.secure/www.ebay.com/",
+            ),
+            (
+                "http://195.127.0.11/uploads/%20%20%20%20/.verify/.eBaysecure=updateuserdataxplimnbqmn-xplmvalidateinfoswqpcmlx=hgplmcx/",
+                "http://195.127.0.11/uploads/%20%20%20%20/.verify/.eBaysecure=updateuserdataxplimnbqmn-xplmvalidateinfoswqpcmlx=hgplmcx/",
+            ),
+            (
+                "http://host%23.com/%257Ea%2521b%2540c%2523d%2524e%25f%255E00%252611%252A22%252833%252944_55%252B",
+                "http://host%23.com/~a!b@c%23d$e%25f^00&11*22(33)44_55+",
+            ),
+            ("http://www.google.com/blah/..", "http://www.google.com/"),
+            ("www.google.com/", "http://www.google.com/"),
+            ("www.google.com", "http://www.google.com/"),
+            ("http://www.evil.com/blah#frag", "http://www.evil.com/blah"),
+            ("http://www.GOOgle.com/", "http://www.google.com/"),
+            ("http://www.google.com.../", "http://www.google.com/"),
+            (
+                "http://www.google.com/foo\tbar\rbaz\n2",
+                "http://www.google.com/foobarbaz2",
+            ),
+            ("http://www.google.com/q?", "http://www.google.com/q?"),
+            ("http://www.google.com/q?r?", "http://www.google.com/q?r?"),
+            ("http://www.google.com/q?r?s", "http://www.google.com/q?r?s"),
+            ("http://evil.com/foo#bar#baz", "http://evil.com/foo"),
+            ("http://evil.com/foo),", "http://evil.com/foo),"),
+            ("http://evil.com/foo?bar),", "http://evil.com/foo?bar),"),
+            ("http://\x01\x80.com/", "http://%01%80.com/"),
+            ("http://notrailingslash.com", "http://notrailingslash.com/"),
+            ("http://www.gotaport.com:1234/", "http://www.gotaport.com/"),
+            ("  http://www.google.com/  ", "http://www.google.com/"),
+            ("http:// leadingspace.com/", "http://%20leadingspace.com/"),
+            ("http://%20leadingspace.com/", "http://%20leadingspace.com/"),
+            ("%20leadingspace.com/", "http://%20leadingspace.com/"),
+            ("https://www.securesite.com/", "https://www.securesite.com/"),
+            ("http://host.com/ab%23cd", "http://host.com/ab%23cd"),
+            (
+                "http://host.com//twoslashes?more//slashes",
+                "http://host.com/twoslashes?more//slashes",
+            ),
+            # Many flavours of IP addresses (added by us mostly)
+            ("http://3279880203/blah", "http://195.127.0.11/blah"),
+            ("http://0303.0177.0000.0013/blah", "http://195.127.0.11/blah"),
+            ("http://030337600013/blah", "http://195.127.0.11/blah"),
+            (
+                "http://11000011.01111111.00000000.00001011/blah",
+                "http://195.127.0.11/blah",
+            ),
+            ("http://c3.7f.00.0b/blah", "http://195.127.0.11/blah"),
+            ("http://0xc37f000b/blah", "http://195.127.0.11/blah"),
+            # Punycode testing (added by us)
+            ("http://ümlaut.com", "http://xn--mlaut-jva.com/"),
+        ),
+    )
+    def test_canonicalise(self, url, canonical_url):
+        result = CanonicalURL.canonicalize(url)
+
+        assert result == canonical_url

--- a/tests/unit/checkmate/url/expand_test.py
+++ b/tests/unit/checkmate/url/expand_test.py
@@ -1,0 +1,56 @@
+import pytest
+
+from checkmate.url.expand import ExpandURL
+
+# Taken from: https://cloud.google.com/web-risk/docs/urls-hashing#suffixprefix_expressions
+TEST_SET = (
+    (
+        "http://a.b.c/1/2.html?param=1",
+        (
+            "a.b.c/1/2.html?param=1",
+            "a.b.c/1/2.html",
+            "a.b.c/",
+            "a.b.c/1/",
+            "b.c/1/2.html?param=1",
+            "b.c/1/2.html",
+            "b.c/",
+            "b.c/1/",
+        ),
+    ),
+    (
+        "http://a.b.c.d.e.f.g/1.html",
+        (
+            "a.b.c.d.e.f.g/1.html",
+            "a.b.c.d.e.f.g/",
+            "c.d.e.f.g/1.html",
+            "c.d.e.f.g/",
+            "d.e.f.g/1.html",
+            "d.e.f.g/",
+            "e.f.g/1.html",
+            "e.f.g/",
+            "f.g/1.html",
+            "f.g/",
+        ),
+    ),
+    (
+        "http://1.2.3.4/1/",
+        (
+            "1.2.3.4/1/",
+            "1.2.3.4/",
+        ),
+    ),
+)
+
+
+class TestExpand:
+    @pytest.mark.parametrize("url,expansions", TEST_SET)
+    def test_expand(self, url, expansions):
+        results = ExpandURL.expand(url)
+
+        assert tuple(results) == expansions
+
+    @pytest.mark.parametrize("url,expansions", TEST_SET)
+    def test_expand_single(self, url, expansions):
+        result = ExpandURL.expand_single(url)
+
+        assert result == expansions[0]

--- a/tests/unit/checkmate/url/hash_test.py
+++ b/tests/unit/checkmate/url/hash_test.py
@@ -1,0 +1,1 @@
+from checkmate.url.hash import hash_for_rule, hash_url


### PR DESCRIPTION
We might eventually want these for working with Web Risk, but for right now, we could do with the normalisation so we can convert URLs like this:

`http:////hello.com` to `http://hello.com`