### PR TITLE
Use web-risk URL normalisation to get the domain from URLs for blocking

### DIFF
--- a/checkmate/checker/url/blocklist.py
+++ b/checkmate/checker/url/blocklist.py
@@ -8,6 +8,8 @@ from urllib.parse import urlparse
 
 from checkmate.checker.url.reason import Reason
 from checkmate.exceptions import MalformedURL
+from checkmate.url import canonicalize
+from checkmate.url.canonicalize import CanonicalURL
 
 
 class Blocklist:
@@ -77,12 +79,7 @@ class Blocklist:
 
     @classmethod
     def _domain(cls, url):
-        parsed_url = urlparse(url)
-
-        if not parsed_url.scheme:
-            parsed_url = urlparse(f"http://{url.lstrip('/')}")
-
-        return parsed_url.hostname
+        return CanonicalURL.canonical_split(url)[1] or None
 
     def _refresh(self):
         if self._file_changed:

--- a/checkmate/checker/url/blocklist.py
+++ b/checkmate/checker/url/blocklist.py
@@ -4,11 +4,9 @@ import fnmatch
 import os
 import re
 from logging import getLogger
-from urllib.parse import urlparse
 
 from checkmate.checker.url.reason import Reason
 from checkmate.exceptions import MalformedURL
-from checkmate.url import canonicalize
 from checkmate.url.canonicalize import CanonicalURL
 
 

--- a/checkmate/url/canonicalize.py
+++ b/checkmate/url/canonicalize.py
@@ -22,6 +22,25 @@ class CanonicalURL:
         :param url: URL to normalise
         :return: A normalised version of the URL
         """
+        parts = cls.canonical_split(url)
+        clean_url = urlunparse(parts)
+
+        # Get around the fact that URL parse strips off the '?' if the query
+        # string is empty
+        if url.endswith("?") and not clean_url.endswith("?"):
+            clean_url += "?"
+
+        return clean_url
+
+    @classmethod
+    def canonical_split(cls, url):
+        """Split a URL into canonical parts.
+
+        Note the fragment is always `None`. It is only returned for
+        compatibility with the arguments of `urllib.parse.urlunparse()`
+
+        :return: Tuple of (scheme, netloc, path, params, query, fragment)
+        """
         scheme, netloc, path, params, query = cls._pre_process_url(url)
 
         netloc = cls._canonicalize_host(netloc)
@@ -32,14 +51,7 @@ class CanonicalURL:
         netloc = cls._partial_quote(netloc)
         path = cls._partial_quote(path)
 
-        clean_url = urlunparse([scheme, netloc, path, params, query, None])
-
-        # Get around the fact that URL parse strips off the '?' if the query
-        # string is empty
-        if url.endswith("?") and not clean_url.endswith("?"):
-            clean_url += "?"
-
-        return clean_url
+        return scheme, netloc, path, params, query, None
 
     BANNED_CHARS = re.compile("[\x09\x0d\x0a]")
     SCHEME_PREFIX = re.compile(r"^([A-z]+):/+")

--- a/tests/unit/checkmate/checker/url/blocklist_test.py
+++ b/tests/unit/checkmate/checker/url/blocklist_test.py
@@ -114,7 +114,7 @@ class TestBlocklist:
 
         assert blocklist.check_url(url) == Any.generator.containing(reasons).only()
 
-    @pytest.mark.parametrize("url", ("http://", "http:///", "http:///foo", "/"))
+    @pytest.mark.parametrize("url", ("http://", "http:///", "/"))
     def test_it_raises_MalformedURL_for_bad_urls(self, url):
         blocklist = Blocklist("missing.txt")
 
@@ -145,6 +145,9 @@ class TestBlocklist:
     def test_domain_extraction(self, url, expected_domain):
         blocklist = Blocklist("missing.txt")
 
+        # This might be naughty but we want to be sure this is ok separately
+        # from the rest.
+        # pylint: disable=protected-access
         domain = blocklist._domain(url)
 
         assert domain == expected_domain

--- a/tests/unit/checkmate/url/canonicalise_test.py
+++ b/tests/unit/checkmate/url/canonicalise_test.py
@@ -68,6 +68,13 @@ class TestCanonicalURL:
             ("http://0xc37f000b/blah", "http://195.127.0.11/blah"),
             # Punycode testing (added by us)
             ("http://ümlaut.com", "http://xn--mlaut-jva.com/"),
+            # Some unspecified behavior around badly formatted URLs (added by
+            # us). The logic being, if Chrome will open it, we should check it
+            ("/example.com", "http://example.com/"),
+            ("//example.com", "http://example.com/"),
+            ("///example.com", "http://example.com/"),
+            ("http:/example.com", "http://example.com/"),
+            ("http:///example.com", "http://example.com/"),
         ),
     )
     def test_canonicalise(self, url, canonical_url):

--- a/tests/unit/checkmate/url/canonicalise_test.py
+++ b/tests/unit/checkmate/url/canonicalise_test.py
@@ -81,3 +81,11 @@ class TestCanonicalURL:
         result = CanonicalURL.canonicalize(url)
 
         assert result == canonical_url
+
+    def test_canonical_split(self):
+        # We don't need to go nuts here, as this is well covered above
+
+        parts = CanonicalURL.canonical_split(
+            "http:/example.com/path/abc;path_param?a=b#foo"
+        )
+        assert parts == ("http", "example.com", "/path/abc", "path_param", "a=b", None)


### PR DESCRIPTION
This does a few things:

 * Fixes up some gaps / undefined behavior in our canonical url method
 * Adds a stage to get the URL after splitting without joining it
 * Uses this to extract the domain more reliably

The hope is this will stop a lot of the 400's we are seeing in checkmate