### PR TITLE
Adding postgres dev dependency to allow us to compile psycopg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ WORKDIR /var/lib/hypothesis
 COPY requirements/requirements.txt ./
 
 # Install build deps, build, and then clean up.
-RUN apk add --no-cache --virtual build-deps \
+RUN apk add --no-cache --virtual \
+    build-deps \
+    build-base \
+    postgresql-dev \
   && pip install --no-cache-dir -U pip \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del build-deps


### PR DESCRIPTION
This shows up as a failure when running through CI or `make docker`

### Testing notes

 * `git checkout main`
 * `make docker` - Should fail with complaints about `psycopg`
 * `git checkout postgres-dependency`
 * `make docker` - Should work!