### PR TITLE
Run a postgres container so the tests can run in CI

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -52,7 +52,7 @@ def pyramid_settings():
 @pytest.fixture(scope="session")
 def db_engine():
     database_url = os.environ.get(
-        "TEST_DATABASE_URL", "postgresql://postgres@localhost:5434/postgres"
+        "TEST_DATABASE_URL", "postgresql://postgres@localhost:5434/checkmate_test"
     )
     if not database_url:  # pragma: no cover
         raise EnvironmentError("TEST_DATABASE_URL required to run tests")


### PR DESCRIPTION
We don't need postgres in Live yet, but we do need it for the tests. This runs a Postgres container in Jenkins to let the tests pass.