### PR TITLE
Add `make shell`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ source =
 omit =
     checkmate/scripts*
     checkmate/migrations/*
+    checkmate/pshell.py
 
 [report]
 show_missing = True

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,6 +1,9 @@
 [pydocstyle]
-ignore = D104,  # Missing docstring in public package
-                # Prevents us from having useless comments in __init__.py
+ignore = D100,  # Missing docstring in public module
+         D101,  # Missing docstring in public class
+         D102,  # Missing docstring in public method
+         D103,  # Missing docstring in public function
+         D104,  # Missing docstring in public package
          D105,  # Missing docstring in magic method
          D106,  # Missing docstring in public nested class
          D107,  # Missing docstring in __init__

--- a/.pylintrc
+++ b/.pylintrc
@@ -17,11 +17,33 @@ enable=
     useless-suppression,
     use-symbolic-message-instead
 
-disable=bad-continuation,
-        missing-type-doc,
-        missing-return-type-doc,
-        too-few-public-methods,
-        missing-yield-type-doc
+disable=
+    # Docstrings are encouraged but we don't want to enforce that everything
+    # must have a docstring.
+    missing-docstring,
+
+    # We don't always want to have to put a `:return:` in a docstring.
+    missing-return-doc,
+
+    # We don't always want to have to put an `:rtype:` in a docstring.
+    missing-return-type-doc,
+
+    # We don't always want to document the types of things with :type: and
+    # :rtype: in docstrings.
+    missing-type-doc,
+    missing-return-type-doc,
+    missing-yield-type-doc,
+
+    # We use isort to sort and group our imports, so we don't need PyLint to
+    # check them for us.
+    ungrouped-imports,
+
+    # We use Black to format our code automatically, so we don't need PyLint to
+    # check formatting for us.
+    bad-continuation,
+    line-too-long,
+
+    too-few-public-methods,
 
 [REPORTS]
 output-format=colorized

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ help:
 	@echo '                       that `make dev` starts, type `help` for docs'
 	@echo 'make services          Run the services that `make dev` requires'
 	@echo 'make db                Upgrade the DB schema to the latest version'
+	@echo "make shell             Launch a Python shell in the dev environment"
 	@echo "make sql               Connect to the dev database with a psql shell"
 	@echo "make lint              Run the code linter(s) and print any warnings"
 	@echo "make format            Correctly format the code"
@@ -35,6 +36,10 @@ db: args?=upgrade head
 db: python
 	@tox -qqe dev --run-command 'initdb conf/development.ini'  # See setup.py for what initdb is.
 	@tox -qe dev  --run-command 'alembic -c conf/alembic.ini $(args)'
+
+.PHONY: shell
+shell: python
+	@tox -qe dev --run-command 'pshell conf/development.ini'
 
 .PHONY: sql
 sql: python

--- a/checkmate/pshell.py
+++ b/checkmate/pshell.py
@@ -1,0 +1,37 @@
+import sys
+from contextlib import suppress
+
+from transaction.interfaces import NoTransaction
+
+from checkmate import models
+
+
+def setup(env):
+    sys.path = ["."] + sys.path
+
+    from tests import factories  # pylint:disable=import-outside-toplevel
+
+    sys.path = sys.path[1:]
+
+    request = env["request"]
+
+    request.tm.begin()
+
+    env["tm"] = request.tm
+    env["tm"].__doc__ = "Active transaction manager (a transaction is already begun)."
+
+    env["db"] = env["session"] = request.db
+    env["db"].__doc__ = "Active DB session."
+
+    env["m"] = env["models"] = models
+    env["m"].__doc__ = "The checkmate.models package."
+
+    env["f"] = env["factories"] = factories
+    env["f"].__doc__ = "The test factories for quickly creating objects."
+    factories.set_sqlalchemy_session(request.db)
+
+    try:
+        yield
+    finally:
+        with suppress(NoTransaction):
+            request.tm.abort()

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -2,3 +2,6 @@
 use = call:checkmate.app:create_app
 debug = true
 dev = true
+
+[pshell]
+setup = checkmate.pshell.setup

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,3 +3,5 @@ ipython
 ipdb
 supervisor
 docker-compose
+pyramid_ipython
+factory-boy

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -25,6 +25,8 @@ docker-compose==1.27.4    # via -r requirements/dev.in
 docker[ssh]==4.4.0        # via docker-compose
 dockerpty==0.4.1          # via docker-compose
 docopt==0.6.2             # via docker-compose
+factory-boy==3.1.0        # via -r requirements/dev.in
+faker==5.0.1              # via factory-boy
 gunicorn==20.0.4          # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1   # via -r requirements/requirements.txt
 hupper==1.10.2            # via -r requirements/requirements.txt, pyramid
@@ -33,7 +35,7 @@ importlib-metadata==3.1.0  # via -r requirements/requirements.txt, jsonschema, k
 importlib-resources==3.3.0  # via -r requirements/requirements.txt, netaddr
 ipdb==0.13.4              # via -r requirements/dev.in
 ipython-genutils==0.2.0   # via traitlets
-ipython==7.16.1           # via -r requirements/dev.in, ipdb
+ipython==7.16.1           # via -r requirements/dev.in, ipdb, pyramid-ipython
 jedi==0.17.2              # via ipython
 jinja2==2.11.2            # via -r requirements/requirements.txt, pyramid-jinja2
 jsonschema==3.2.0         # via docker-compose
@@ -56,11 +58,12 @@ pycparser==2.20           # via cffi
 pygments==2.7.2           # via ipython
 pynacl==1.4.0             # via paramiko
 pyramid-exclog==1.0       # via -r requirements/requirements.txt
+pyramid-ipython==0.2      # via -r requirements/dev.in
 pyramid-jinja2==2.8       # via -r requirements/requirements.txt
 pyramid-tm==2.4           # via -r requirements/requirements.txt
-pyramid==1.10.5           # via -r requirements/requirements.txt, h-pyramid-sentry, pyramid-exclog, pyramid-jinja2, pyramid-tm
+pyramid==1.10.5           # via -r requirements/requirements.txt, h-pyramid-sentry, pyramid-exclog, pyramid-ipython, pyramid-jinja2, pyramid-tm
 pyrsistent==0.17.3        # via jsonschema
-python-dateutil==2.8.1    # via -r requirements/requirements.txt, alembic
+python-dateutil==2.8.1    # via -r requirements/requirements.txt, alembic, faker
 python-dotenv==0.15.0     # via docker-compose
 python-editor==1.0.4      # via -r requirements/requirements.txt, alembic
 pytz==2020.4              # via -r requirements/requirements.txt, celery
@@ -70,6 +73,7 @@ sentry-sdk==0.19.4        # via -r requirements/requirements.txt, h-pyramid-sent
 six==1.15.0               # via -r requirements/requirements.txt, bcrypt, click-repl, cryptography, docker, dockerpty, jsonschema, pynacl, python-dateutil, traitlets, websocket-client
 sqlalchemy==1.3.20        # via -r requirements/requirements.txt, alembic, zope.sqlalchemy
 supervisor==4.2.1         # via -r requirements/dev.in
+text-unidecode==1.3       # via faker
 texttable==1.6.3          # via docker-compose
 traitlets==4.3.3          # via ipython
 transaction==3.0.0        # via -r requirements/requirements.txt, pyramid-tm, zope.sqlalchemy


### PR DESCRIPTION
The same as our other apps have, launches an iPython shell in the dev virtualenv, which means it's using the right version of Python and all the packages are available to import. This is very handy:

    $ make shell
    Python 3.6.9 (default, Dec  6 2020, 21:12:12)
    Type 'copyright', 'credits' or 'license' for more information
    IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

    Environment:
    app          The WSGI application.
    db           Active DB session.
    f            The test factories for quickly creating objects.
    factories    The test factories for quickly creating objects.
    m            The checkmate.models package.
    models       The checkmate.models package.
    registry     Active Pyramid registry.
    request      Active request object.
    root         Root of the default resource tree.
    root_factory Default root factory used to create `root`.
    session      Active DB session.
    tm           Active transaction manager (a transaction is already begun).

    In [1]: db.query(m.CustomRule).first()
    Out[1]: CustomRule(id=97, rule='nautil.us/', hash='05d4a5a43fbb107f5b086b08608e474144f1a70a9a7c62041b1fb57d437c2dbf', tags=['publisher-blocked'])

    In [2]: factories.CustomRule()
    Out[2]: CustomRule(id=None, rule='www.smith.com/', hash='86a1a55d4647694a221d4d50a271cd270b2276bb7dddd8dea228d58f30b83a36', tags=['high-io'])