### PR TITLE
Looks like we need another library for Postgres access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6.9-alpine3.10
 LABEL maintainer="Hypothes.is Project and contributors"
 
 # Install nginx & supervisor
-RUN apk add --no-cache nginx gettext supervisor curl
+RUN apk add --no-cache nginx gettext supervisor curl libpq
 
 # Create the hypothesis user, group, home directory and package directory.
 RUN addgroup -S hypothesis && adduser -S -G hypothesis -h /var/lib/hypothesis hypothesis


### PR DESCRIPTION
Currently when adding DB connection details we get:

```
    module = self.loader.load_module(fullname)
   File "/usr/local/lib/python3.6/site-packages/psycopg2/__init__.py", line 51, in <module>
     from psycopg2._psycopg import (                     # noqa
 ImportError: Error loading shared library libpq.so.5: No such file or directory (needed by /usr/local/lib/python3.6/site-
```

I think this _might_ be because we are missing `libpq`. It's in LMS