### PR TITLE
Exit on failure to start the app for the Celery worker

### DIFF
--- a/checkmate/async/celery.py
+++ b/checkmate/async/celery.py
@@ -1,7 +1,9 @@
 """Celery app and configuration."""
 
 import os
+import sys
 from contextlib import contextmanager
+from logging import getLogger
 
 import celery.signals
 from celery import Celery
@@ -10,6 +12,9 @@ from pyramid.scripting import prepare
 
 from checkmate.app import create_app
 from checkmate.async.policy import RETRY_POLICY_QUICK
+
+LOG = getLogger(__name__)
+
 
 app = Celery("checkmate")
 app.conf.update(
@@ -47,7 +52,16 @@ def bootstrap_worker(sender, **_kwargs):  # pragma: no cover
     """Set up the celery worker with one-time initialisation."""
 
     # Put some common handy things around for tasks
-    checkmate = create_app(celery_worker=True)
+    try:
+        checkmate = create_app(celery_worker=True)
+
+    # pylint: disable=broad-except
+    except Exception as err:
+        # If we don't bail out here ourselves, Celery just hides the error
+        # and continues. This means `request_context` will not be available
+        # when attempting to run tasks, which is impossible to debug.
+        LOG.fatal("CELERY WORKER DID NOT START: Could not create app: %s", err)
+        sys.exit(1)
 
     @contextmanager
     def request_context():

--- a/checkmate/async/celery.py
+++ b/checkmate/async/celery.py
@@ -55,12 +55,11 @@ def bootstrap_worker(sender, **_kwargs):  # pragma: no cover
     try:
         checkmate = create_app(celery_worker=True)
 
-    # pylint: disable=broad-except
-    except Exception as err:
+    except Exception:  # pylint: disable=broad-except
         # If we don't bail out here ourselves, Celery just hides the error
         # and continues. This means `request_context` will not be available
         # when attempting to run tasks, which is impossible to debug.
-        LOG.fatal("CELERY WORKER DID NOT START: Could not create app: %s", err)
+        LOG.critical("CELERY WORKER DID NOT START: Could not create app", exc_info=True)
         sys.exit(1)
 
     @contextmanager

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -14,6 +14,7 @@ command=newrelic-admin run-program celery -A checkmate.async.celery:app worker -
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true
+stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
 

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,10 +12,11 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:worker]
-command=newrelic-admin run-program celery -A checkmate.async.celery:app worker --loglevel=INFO
+command=newrelic-admin run-program celery -A checkmate.async.celery:app worker --loglevel INFO
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true
+stderr_events_enabled=true
 
 [program:refresh_blocklist]
 command=sh -c "while true; do bin/fetch-blocklist; sleep 60; done"

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,8 @@ setenv =
     dev: SENTRY_ENVIRONMENT = {env:SENTRY_ENVIRONMENT:dev}
     dev: CELERY_BROKER_URL={env:CELERY_BROKER_URL:amqp://guest:guest@localhost:5673//}
     dev: DATABASE_URL={env:DATABASE_URL:postgresql://postgres@localhost:5434/postgres}
-    dev: CHECKMATE_BLOCKLIST_PATH = conf/blocklist-dev.txt
+    dev: CHECKMATE_BLOCKLIST_URL = {env:CHECKMATE_BLOCKLIST_URL:http://dummy.example.com/blocklist}
+    dev: CHECKMATE_BLOCKLIST_PATH = {env:CHECKMATE_BLOCKLIST_PATH:conf/blocklist-dev.txt}
     tests: TEST_DATABASE_URL = {env:TEST_DATABASE_URL:postgresql://postgres@localhost:5434/checkmate_test}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 


### PR DESCRIPTION
Things fixed in this PR:

 * If the app fails to create the worker fails to start
 * Added config to allow the app to start (but not work fully) in dev
 * Fixed STDERR logging for celery

Previously if there was any problem with the Celery worker init signal Celery would hide it and carry on. This exits the whole process (as it can't work).

This also adds a dummy value for the URL to make sure that we can start. This doesn't work (and will be removed soon), but it's good enough to start the app and see the task fail to run.

This only effected dev at present, as all the values required to start are in prod, but any issue in prod would have created a very difficult debugging session.

### Testing notes

 * Comment out an env var in `tox.ini` like `DATABASE_URL`
 * Run `make dev` 
 * You should now see Celery fail to start (starts but broken in `main`)