### PR TITLE
Use scan not include now the views have no includeme() functions

### DIFF
--- a/checkmate/app.py
+++ b/checkmate/app.py
@@ -72,7 +72,7 @@ def configure(config, celery_worker=False):  # pragma: no cover
         # The celery workers don't need to know about this stuff
         config.include("pyramid_jinja2")
 
-        config.include("checkmate.views")
+        config.scan("checkmate.views")
         config.include("checkmate.routes")
 
     config.include("checkmate.models")

--- a/checkmate/views/__init__.py
+++ b/checkmate/views/__init__.py
@@ -1,7 +1,0 @@
-"""The views for the Pyramid app."""
-
-
-def includeme(config):  # pragma: no cover
-    """Pyramid config."""
-    config.scan("checkmate.views")
-    config.include("checkmate.views.api.check_url")


### PR DESCRIPTION
The previous work on removing the file based systems removed an `includeme()` which means we fail now. We don't need it, so scanning is the way to go.

Literally any functional test might have picked this up (app doesn't start). That might be a good thing to add... but no

### Testing notes

 * Run `make dev`
 * It doesn't crash any more! (Not true in main)