### PR TITLE
Separate out hashing and updating into mixins

### DIFF
--- a/checkmate/checker/url/custom_rules.py
+++ b/checkmate/checker/url/custom_rules.py
@@ -47,7 +47,7 @@ class CustomRules:
         # Note: This currently has no way of removing things from the DB
         # Soon this won't matter as we won't be doing this any more
 
-        CustomRule.bulk_update(
+        CustomRule.bulk_upsert(
             self._session,
             values=[
                 self._value_from_domain(domain, reason)

--- a/checkmate/models/db/custom_rule.py
+++ b/checkmate/models/db/custom_rule.py
@@ -1,72 +1,36 @@
 """Model for our own blocking rules."""
 
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import ARRAY, insert
-from zope.sqlalchemy import mark_changed
+from sqlalchemy.dialects.postgresql import ARRAY
 
 from checkmate.checker.url.reason import Reason
 from checkmate.db import BASE
+from checkmate.models.db.mixins import BulkUpsertMixin, HashMatchMixin
 
 
-class CustomRule(BASE):
+class CustomRule(BASE, HashMatchMixin, BulkUpsertMixin):
     """Rule about blocking a particular resource."""
+
+    BULK_UPSERT_INDEX_ELEMENTS = ["rule"]
+    BULK_UPSERT_UPDATE_ELEMENTS = ["hash", "tags"]
 
     __tablename__ = "custom_rule"
 
     id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    hash = HashMatchMixin.hash_column(unique=True)
+    """A hash for quick comparison."""
 
     # While our hashes should be unique, we might change our mind about how
     # we hash. The rule itself should stay the same
     rule = sa.Column(sa.String, nullable=False, unique=True)
     """The text of the rule"""
 
-    # We'd like to know if we have a hash collision
-    # The C collation here allows the B-Tree default indexing type to be used
-    # for prefix matching. This makes searching for 'ab2d23d45a%' very quick
-    # https://www.postgresql.org/docs/11/indexes-types.html
-    hash = sa.Column(sa.String(collation="C"), nullable=False, unique=True, index=True)
-    """A hash for quick comparison"""
-
     tags = sa.Column(ARRAY(sa.String, dimensions=1))
     """The list of reasons why we are blocking this"""
 
-    @staticmethod
-    def bulk_update(session, values):  # pragma: no cover
-        """Create or update a number of rows at once.
-
-        This will match on the "rule" portion and must include "hash" and
-        "tags". This will not delete any rows.
-
-        :param session: DB session to execute within
-        :param values: A list of dicts of columns to update
-        """
-        stmt = insert(CustomRule).values(values)
-        stmt = stmt.on_conflict_do_update(
-            # Match when the rules are the same
-            index_elements=["rule"],
-            # Then set these elements
-            set_={"hash": stmt.excluded.hash, "tags": stmt.excluded.tags},
-        )
-
-        session.execute(stmt)
-
-        # Let SQLAlchemy know that something has changed, otherwise it will
-        # never commit the transaction we are working on and it will get rolled
-        # back
-        mark_changed(session)
-
     @property
     def reasons(self):
-        """Get a list of reason object for this rule."""
+        """Get a list of reason objects for this rule."""
 
         return [Reason.parse(tag) for tag in self.tags]
-
-    @staticmethod
-    def find_matches(session, hex_hashes):
-        """Find matching rules for the specified hashes.
-
-        :param session: DB session to execute within
-        :param hex_hashes: List of URL hashes to find
-        :return: Iterable of matching CustomRule objects
-        """
-        return session.query(CustomRule).filter(CustomRule.hash.in_(hex_hashes))

--- a/checkmate/models/db/mixins.py
+++ b/checkmate/models/db/mixins.py
@@ -1,0 +1,117 @@
+"""Mixins to enhance model objects."""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert
+from zope.sqlalchemy import mark_changed
+
+
+class HashMatchMixin:
+    """A mixin for models which want to support hash based URL comparisons.
+
+    Your subclass must have a column like this:
+        hash = HashMatchMixin.hash_column()
+    """
+
+    @staticmethod
+    def hash_column(unique=False):
+        """Return a column suitable for hashing which you must call "hash"."""
+
+        # The C collation here allows the B-Tree default indexing type to be
+        # used for prefix matching. This makes searching for 'ab2d23d45a%'
+        # very quick: https://www.postgresql.org/docs/11/indexes-types.html
+        return sa.Column(
+            sa.String(collation="C"), nullable=False, index=True, unique=unique
+        )
+
+    @classmethod
+    def find_matches(cls, session, hex_hashes, limit=None):
+        """Find matching rules for the specified hashes.
+
+        :param session: DB session to execute within
+        :param hex_hashes: List of URL hashes to find
+        :param limit: Limit the number of returned values
+        :return: Iterable of matching CustomRule objects
+        """
+
+        query = session.query(cls).filter(cls.hash.in_(hex_hashes))
+
+        if limit:
+            query = query.limit(limit)
+
+        return query
+
+
+class BulkUpsertMixin:
+    """A mixin for models that want to support bulk upserting."""
+
+    BULK_UPSERT_INDEX_ELEMENTS = None
+    """Elements to detect collisions on."""
+
+    BULK_UPSERT_UPDATE_ELEMENTS = None
+    """Elements to set in the event of a collision."""
+
+    BLOCK_SIZE = 10000
+    """Numer of elements to attempt to update in one go."""
+
+    @classmethod
+    def bulk_upsert(cls, session, values):
+        """Create or update a number of rows at once.
+
+        This will match on the "rule" portion and must include "hash" and
+        "tags". This will not delete any rows.
+
+        :param session: DB session to execute within
+        :param values: A list of dicts of columns to update
+        :raise NotImplementedError: If you have not provided the expected class
+            values
+        """
+
+        if not cls.BULK_UPSERT_INDEX_ELEMENTS or not cls.BULK_UPSERT_UPDATE_ELEMENTS:
+            raise NotImplementedError(
+                "You must provide the correct elements for this mixin to work"
+            )
+
+        total_items = 0
+        for block in cls._chunk(values):
+            total_items += len(block)
+
+            cls._bulk_upsert(
+                session,
+                block,
+                index_elements=cls.BULK_UPSERT_INDEX_ELEMENTS,
+                update_elements=cls.BULK_UPSERT_UPDATE_ELEMENTS,
+            )
+
+    @classmethod
+    def _chunk(cls, values):
+        block = []
+
+        for value in values:
+            block.append(value)
+
+            if len(block) >= cls.BLOCK_SIZE:
+                yield block
+                block = []
+
+        if block:
+            yield block
+
+    @classmethod
+    def _bulk_upsert(cls, session, values, index_elements, update_elements):
+        stmt = insert(cls).values(values)
+
+        stmt = stmt.on_conflict_do_update(
+            # Match when the rules are the same
+            index_elements=index_elements,
+            # Then set these elements
+            set_={
+                element: getattr(stmt.excluded, element) for element in update_elements
+            },
+        )
+
+        session.execute(stmt)
+
+        # Let SQLAlchemy know that something has changed, otherwise it will
+        # never commit the transaction we are working on and it will get rolled
+        # back
+        mark_changed(session)

--- a/tests/unit/checkmate/models/db/custom_rule_test.py
+++ b/tests/unit/checkmate/models/db/custom_rule_test.py
@@ -1,20 +1,11 @@
 import pytest
 
 from checkmate.checker.url.reason import Reason
-from checkmate.models.db.custom_rule import CustomRule
 from tests import factories
 
 
 @pytest.mark.usefixtures("db_session")
 class TestCustomRule:
-    def test_it_matches(self, db_session):
-        hit = factories.CustomRule()
-        _noise = factories.CustomRule()
-
-        hits = CustomRule.find_matches(db_session, [hit.hash, "non_matching_hash"])
-
-        assert list(hits) == [hit]
-
     def test_reasons(self):
         reasons = [Reason.HIGH_IO, Reason.MEDIA_IMAGE]
 

--- a/tests/unit/checkmate/models/db/mixins_test.py
+++ b/tests/unit/checkmate/models/db/mixins_test.py
@@ -1,0 +1,100 @@
+from unittest.mock import sentinel
+
+import pytest
+import sqlalchemy as sa
+from h_matchers import Any
+
+from checkmate.db import BASE
+from checkmate.models.db.mixins import BulkUpsertMixin, HashMatchMixin
+
+
+class TestHashMatchMixin:
+    class TableWithHash(BASE, HashMatchMixin):
+        __tablename__ = "test_table_with_hash"
+
+        id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+        hash = HashMatchMixin.hash_column()
+
+    def test_it_retrieves_all(self, db_session):
+        items = self.TableWithHash.find_matches(
+            db_session, hex_hashes=["hash_1", "hash_3"]
+        )
+        assert [item.hash for item in items] == Any.list.containing(
+            ["hash_1", "hash_3"]
+        ).only()
+
+    def test_it_with_limit(self, db_session):
+        items = self.TableWithHash.find_matches(
+            db_session, hex_hashes=["hash_1", "hash_3"], limit=1
+        )
+        assert items.count() == 1
+        assert items[0].hash in ["hash_1", "hash_3"]
+
+    @pytest.fixture(autouse=True)
+    def hashes(self, db_session):
+        db_session.add_all(
+            [
+                self.TableWithHash(hash="hash_1"),
+                self.TableWithHash(hash="hash_2"),
+                self.TableWithHash(hash="hash_3"),
+            ]
+        )
+
+
+class TestBulkUpsertMixin:
+    class TableWithBulkUpsert(BASE, BulkUpsertMixin):
+        __tablename__ = "test_table_with_bulk_upsert"
+
+        BULK_UPSERT_INDEX_ELEMENTS = ["id"]
+        BULK_UPSERT_UPDATE_ELEMENTS = ["name"]
+        BLOCK_SIZE = 2
+
+        id = sa.Column(sa.Integer, primary_key=True)
+        name = sa.Column(sa.String)
+        other = sa.Column(sa.String)
+
+    # Vary the block size to catch an exact multiple and multiple blocks
+    @pytest.mark.parametrize("block_size", [2, 3])
+    def test_it_can_be_upserted(self, db_session, block_size):
+        db_session.add_all(
+            [
+                self.TableWithBulkUpsert(id=1, name="pre_existing_1", other="pre_1"),
+                self.TableWithBulkUpsert(id=2, name="pre_existing_2", other="pre_2"),
+            ]
+        )
+        db_session.flush()
+        self.TableWithBulkUpsert.BLOCK_SIZE = block_size
+
+        self.TableWithBulkUpsert.bulk_upsert(
+            db_session,
+            [
+                {"id": 1, "name": "update_old", "other": "post_1"},
+                {"id": 3, "name": "create_with_id", "other": "post_3"},
+                {"id": 4, "name": "over_block_size", "other": "post_4"},
+            ],
+        )
+
+        rows = list(db_session.query(self.TableWithBulkUpsert))
+
+        assert (
+            rows
+            == Any.iterable.containing(
+                [
+                    Any.instance_of(self.TableWithBulkUpsert).with_attrs(expected)
+                    for expected in [
+                        {"id": 1, "name": "update_old", "other": "pre_1"},
+                        {"id": 2, "name": "pre_existing_2", "other": "pre_2"},
+                        {"id": 3, "name": "create_with_id", "other": "post_3"},
+                        {"id": 4, "name": "over_block_size", "other": "post_4"},
+                    ]
+                ]
+            ).only()
+        )
+
+    def test_it_fails_with_badly_configured_host_class(self):
+        class BadTable(BASE, BulkUpsertMixin):
+            __tablename__ = "bad_table"
+            id = sa.Column(sa.Integer, primary_key=True)
+
+        with pytest.raises(NotImplementedError):
+            BadTable.bulk_upsert(sentinel.session, [{}])


### PR DESCRIPTION
In this PR:

 * Functionality that is in the `CustomRule` class is exported out into mixins
 * The mixins provide searching by hash and bulk upsert functionality
 * Renamed bulk update to bulk upsert (as it creates too)

This also fleshes out the updating mixin to chunk it's work. This is because we're going to want all of this for URLHaus, and it's also a convenient way of breaking up a bigger PR.

### Review notes

* I was swithering about having the mixin add the column itself
* Pro: Very simple, you can't mess up using it
* Con: Tables no longer locally declare all of their fields
* Con: All users have to have the same column (we want them to be unique here, but not elsewhere)
* In the end I went with a function to generate it from the mixin to try and capture some of both