### PR TITLE
Fix stat reporting for bulk updates

### DIFF
--- a/checkmate/checker/url/url_haus.py
+++ b/checkmate/checker/url/url_haus.py
@@ -65,7 +65,7 @@ class URLHaus:
 
     def _update(self, feed):
         with TemporaryDirectory() as working_dir:
-            URLHausRule.bulk_upsert(
+            return URLHausRule.bulk_upsert(
                 session=self._session,
                 values=(self._value_from_row(row) for row in feed(working_dir)),
             )

--- a/checkmate/models/db/mixins.py
+++ b/checkmate/models/db/mixins.py
@@ -82,6 +82,8 @@ class BulkUpsertMixin:
                 update_elements=cls.BULK_UPSERT_UPDATE_ELEMENTS,
             )
 
+        return total_items
+
     @classmethod
     def _chunk(cls, values):
         block = []

--- a/tests/unit/checkmate/models/db/mixins_test.py
+++ b/tests/unit/checkmate/models/db/mixins_test.py
@@ -65,7 +65,7 @@ class TestBulkUpsertMixin:
         db_session.flush()
         self.TableWithBulkUpsert.BLOCK_SIZE = block_size
 
-        self.TableWithBulkUpsert.bulk_upsert(
+        result = self.TableWithBulkUpsert.bulk_upsert(
             db_session,
             [
                 {"id": 1, "name": "update_old", "other": "post_1"},
@@ -73,6 +73,8 @@ class TestBulkUpsertMixin:
                 {"id": 4, "name": "over_block_size", "other": "post_4"},
             ],
         )
+
+        assert result == 3
 
         rows = list(db_session.query(self.TableWithBulkUpsert))
 


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/62

Proving the old addage: If you didn't test for it, it's broken

Previously we would log "None" as the number of values synced. This doesn't fix our other issues with actually seeing any logging, but should mean the values we do see tell us more.