### PR TITLE
Upping the log buffer size so we can see what's going missing

### DIFF
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -20,11 +20,10 @@ stopasgroup = true
 
 [eventlistener:logger]
 command=bin/logger --dev
-buffer_size=100
+buffer_size=1024
 events=PROCESS_LOG
 stderr_logfile=/dev/fd/1
 stderr_logfile_maxbytes=0
-stdout_logfile=/dev/null
 
 [unix_http_server]
 file = .supervisor.sock

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -20,7 +20,7 @@ stderr_events_enabled=true
 
 [eventlistener:logger]
 command=bin/logger
-buffer_size=100
+buffer_size=1024
 events=PROCESS_LOG
 stderr_logfile=/dev/fd/1
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
For: #62

This is intended to try and fix the issue where we see this in the logs:

```
Dec 15 15:15:00 checkmate-prod_i-01e9884e60dd7f2ef eb-7d63ba25ca1a-stdouterr.log 2020-12-15 15:15:00,026 ERRO pool logger event buffer overflowed, discarding event 106
Dec 15 15:15:18 checkmate-prod_i-01e9884e60dd7f2ef eb-7d63ba25ca1a-stdouterr.log 2020-12-15 15:15:18,052 ERRO pool logger event buffer overflowed, discarding event 107
Dec 15 15:15:18 checkmate-prod_i-01e9884e60dd7f2ef eb-7d63ba25ca1a-stdouterr.log 2020-12-15 15:15:18,098 ERRO pool logger event buffer overflowed, discarding event 108
```

We may find out what's wrong and be able to fix it, or it might just be that our logging script genuinely can't keep up with the rate of access in live?