### PR TITLE
Add tags > 1 constraint to AllowRule model

### DIFF
--- a/checkmate/models/db/allow_rule.py
+++ b/checkmate/models/db/allow_rule.py
@@ -32,6 +32,7 @@ class AllowRule(BASE, HashMatchMixin):
     )
 
     tags = sa.Column(
-        ARRAY(sa.String, dimensions=1), server_default="{}", nullable=False
+        ARRAY(sa.String, dimensions=1),
+        sa.CheckConstraint("cardinality(tags) > 0", name="tags_cardinality"),
     )
     """A list of tags documenting where this rule came from."""

--- a/tests/unit/checkmate/models/db/allow_rule_test.py
+++ b/tests/unit/checkmate/models/db/allow_rule_test.py
@@ -1,0 +1,12 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from checkmate.models import AllowRule
+
+
+class TestAllowRule:
+    def test_you_cant_make_an_AllowRule_with_no_tags(self, db_session):
+        db_session.add(AllowRule(hash="foo", rule="bar", tags=[]))
+
+        with pytest.raises(IntegrityError, match="ck__allow_rule__tags_cardinality"):
+            db_session.flush()


### PR DESCRIPTION
Instead of a `server_default` and a `NOT NULL` constraint, use a `tags > 1` constraint. Ensures that every row is both not null and has at least one tag.

This will require a DB migration to:

* Back-fill any existing rows that have an empty tags array with at least one tag
* Remove the `server_default`
* Remove the NOT NULL constraint
* Add the check contstraint