### PR TITLE
Add domain introspection tools

### DIFF
--- a/checkmate/url/__init__.py
+++ b/checkmate/url/__init__.py
@@ -4,5 +4,6 @@ For more details see: https://cloud.google.com/web-risk/docs/urls-hashing
 """
 
 from checkmate.url.canonicalize import CanonicalURL
+from checkmate.url.domain import Domain
 from checkmate.url.expand import ExpandURL
 from checkmate.url.hash import hash_for_rule, hash_url

--- a/checkmate/url/domain/__init__.py
+++ b/checkmate/url/domain/__init__.py
@@ -1,3 +1,4 @@
+from checkmate.url.domain.domain import Domain
 from checkmate.url.domain.enums import SuffixType
 from checkmate.url.domain.public_suffix import PublicSuffix
 from checkmate.url.domain.top_level_domain import TopLevelDomain

--- a/checkmate/url/domain/domain.py
+++ b/checkmate/url/domain/domain.py
@@ -1,0 +1,151 @@
+from functools import lru_cache
+
+from checkmate.url.domain._domain_core import DomainCore
+from checkmate.url.domain.public_suffix import PublicSuffix
+from checkmate.url.domain.top_level_domain import TopLevelDomain
+
+
+class Domain(DomainCore):
+    """Represent a domain string with metadata."""
+
+    # This class differs from DomainCore, in that it stitches together a lot of
+    # information from other classes. The DomainCore is needed to allow those
+    # classes to make use of some of the basic functionality without getting in
+    # an import loop.
+
+    @property
+    def is_public(self):
+        """Get whether the domain is publicly available."""
+
+        if self.is_ip_v4:
+            return not self.is_private_ip_v4
+
+        return self.is_fully_qualified
+
+    @property
+    @lru_cache(1)
+    def is_fully_qualified(self):
+        """Get whether the domain is a fully qualified domain name (public).
+
+        IP addresses are not considered fully qualified, as they have no top
+        level domain.
+        """
+
+        if not self.is_valid:
+            return False
+
+        # We have a proper suffix, and it's not the whole domain name
+        return bool(self.icann_suffix) and (self != self.icann_suffix)
+
+    @property
+    def tld(self):
+        """Get the top level domain (if any)."""
+
+        if TopLevelDomain.is_tld(self):
+            return str(self)
+
+        return TopLevelDomain.get_tld(self)
+
+    @property
+    def public_suffix(self):
+        """Get the public suffix for this domain.
+
+        This includes recognised suffixes from ICANN (such as `co.uk`) and
+        private companies (`github.io`). In many cases this will be identical
+        to the top level domain.
+        """
+
+        if self.is_ip_v4:
+            return None
+
+        return PublicSuffix.get_suffix(self, icann_only=False)
+
+    @property
+    def icann_suffix(self):
+        """Get the ICANN registered suffix for this domain.
+
+        This includes recognised suffixes from ICANN (such as `co.uk`) but not
+        private companies.
+        """
+        if self.is_ip_v4:
+            return None
+
+        return PublicSuffix.get_suffix(self, icann_only=True)
+
+    @property
+    def suffix_type(self):
+        """Get the suffix type of this domain (if any).
+
+        This will tell you if the domain has a private, or ICANN recognised
+        suffix. All private suffixes will have a ICANN recognised suffix in
+        addition.
+        """
+        if self.is_ip_v4:
+            return None
+
+        return PublicSuffix.suffix_type(PublicSuffix.get_suffix(self))
+
+    @lru_cache(2)
+    def split_domain(self, icann_only=False):
+        """Split a domain into a root domain and sub-domain labels.
+
+        For example:
+            a.b.c.co.uk -> ["a", "b"], "c.co.uk"
+
+        In the case of an IP address or a domain string consisting of only a
+        suffix, this will result in empty subdomains and the domain value
+        returned as the root domain.
+
+        :param icann_only: Only include ICANN recognised suffixes, not private
+            ones
+        :returns: A tuple consisting of (a list of sub-domain labels, root domain)
+        """
+        if self.is_ip_v4:
+            return [], str(self)
+
+        suffix = PublicSuffix.get_suffix(self, icann_only)
+        if not suffix or suffix == self:
+            return [], str(self)
+
+        labels = self[: -len(suffix) - 1].split(".")
+        root_domain = f"{labels[-1]}.{suffix}"
+
+        return labels[:-1], root_domain
+
+    @property
+    def root_domain(self):
+        """Get the root domain without any sub-domains.
+
+        Domains with different root domains can be considered different (but
+        possibly related) sites.
+
+        For example:
+
+            www.google.com -> google.com
+            a.b.c.github.io -> c.github.io
+        """
+        _, root_domain = self.split_domain(icann_only=False)
+
+        return root_domain
+
+    def as_dict(self):
+        suffix_type = self.suffix_type
+
+        return {
+            "domain": str(self),
+            "meta": {
+                "is_valid": self.is_valid,
+                "is_public": self.is_public,
+                "is_fully_qualified": self.is_fully_qualified,
+                "is_ip_v4": self.is_ip_v4,
+                "is_private_ip_v4": self.is_private_ip_v4,
+            },
+            "split_domain": self.split_domain(),
+            "root_domain": self.root_domain,
+            "suffix": {
+                "type": None if suffix_type is None else suffix_type.value,
+                "tld": self.tld,
+                "public": self.public_suffix,
+                "icann": self.icann_suffix,
+            },
+        }

--- a/tests/unit/checkmate/url/domain/domain_test.py
+++ b/tests/unit/checkmate/url/domain/domain_test.py
@@ -1,0 +1,144 @@
+import pytest
+from h_matchers import Any
+
+from checkmate.url import Domain
+from checkmate.url.domain.enums import SuffixType
+
+
+class TestDomain:
+    # These methods are quite often really just combinations of other things
+    # so we'll be giving some a quite light touch
+
+    @pytest.mark.parametrize(
+        "domain,is_public",
+        (
+            ("www.example.com", True),
+            ("  www.whitespace.com", True),
+            ("216.58.212.206", True),
+            ("192.168.34.11", False),
+            ("bad.-hyphen.com", False),
+            ("plausable.but-wrong.dato", False),
+            ("random_hostname", False),
+            ("<html>", False),
+        ),
+    )
+    def test_is_public(self, domain, is_public):
+        assert Domain(domain).is_public == is_public
+
+    @pytest.mark.parametrize(
+        "domain,is_fqdn",
+        (
+            ("com", False),
+            ("co.uk", False),
+            ("more.com", True),
+            ("www.example.com", True),
+            ("  www.whitespace.com", True),
+            ("216.58.212.206", False),  # IPs are not fully qualified
+            ("bad.-hyphen.com", False),
+            ("plausable.but-wrong.dato", False),
+            ("random_hostname", False),
+            ("<html>", False),
+        ),
+    )
+    def test_is_fully_qualified(self, domain, is_fqdn):
+        assert Domain(domain).is_fully_qualified == is_fqdn
+
+    @pytest.mark.parametrize(
+        "domain,tld",
+        (
+            ("www.example.com", "com"),
+            ("com", "com"),
+            ("www.example.not_a_tld", None),
+            ("10.0.0.1", None),
+        ),
+    )
+    def test_tld(self, domain, tld):
+        assert Domain(domain).tld == tld
+
+    @pytest.mark.parametrize(
+        "domain,public_suffix",
+        (
+            ("com", "com"),
+            ("co.uk", "co.uk"),
+            ("www.example.com", "com"),
+            ("www.example.co.uk", "co.uk"),
+            ("page.github.io", "github.io"),
+            ("nonsense", None),
+            ("10.0.0.1", None),
+        ),
+    )
+    def test_public_suffix(self, domain, public_suffix):
+        assert Domain(domain).public_suffix == public_suffix
+
+    @pytest.mark.parametrize(
+        "domain,icann_suffix",
+        (
+            ("com", "com"),
+            ("co.uk", "co.uk"),
+            ("www.example.com", "com"),
+            ("www.example.co.uk", "co.uk"),
+            ("page.github.io", "io"),
+            ("nonsense", None),
+            ("10.0.0.1", None),
+        ),
+    )
+    def test_icann_suffix(self, domain, icann_suffix):
+        assert Domain(domain).icann_suffix == icann_suffix
+
+    @pytest.mark.parametrize(
+        "domain,suffix_type",
+        (
+            ("com", SuffixType.ICANN),
+            ("www.example.com", SuffixType.ICANN),
+            ("www.example.co.uk", SuffixType.ICANN),
+            ("page.github.io", SuffixType.PRIVATE),
+            ("github.io", SuffixType.PRIVATE),
+            ("nonsense", None),
+            ("10.0.0.1", None),
+        ),
+    )
+    def test_suffix_type(self, domain, suffix_type):
+        assert Domain(domain).suffix_type == suffix_type
+
+    @pytest.mark.parametrize(
+        "domain,icann_only,sub_domains,root_domain",
+        (
+            ("www.example.com", False, ["www"], "example.com"),
+            ("a.page.github.io", False, ["a"], "page.github.io"),
+            ("github.io", False, [], "github.io"),
+            ("a.page.github.io", True, ["a", "page"], "github.io"),
+            # Lets say IPs are their own root domain
+            ("10.0.0.1", False, [], "10.0.0.1"),
+            # Is there any sensible way to deal with things without public
+            # suffixes? We don't know where to start or stop here
+            ("my_home_pc", False, [], "my_home_pc"),
+            ("a.b.c.d.e.my_home_pc.local", False, [], "a.b.c.d.e.my_home_pc.local"),
+        ),
+    )
+    def test_split_domain(self, domain, icann_only, sub_domains, root_domain):
+        values = Domain(domain).split_domain(icann_only)
+
+        assert values == (sub_domains, root_domain)
+
+    @pytest.mark.parametrize(
+        "domain,root_domain",
+        (
+            ("www.example.com", "example.com"),
+            ("www2.example.com", "example.com"),
+            ("a.b.example.com", "example.com"),
+            ("a.b.c.page.github.io", "page.github.io"),
+            # Lets say IPs are their own root domain
+            ("10.0.0.1", "10.0.0.1"),
+            # Is there any sensible way to deal with things without public
+            # suffixes? We don't know where to start or stop here
+            ("my_home_pc", "my_home_pc"),
+            ("a.b.c.d.e.my_home_pc.local", "a.b.c.d.e.my_home_pc.local"),
+        ),
+    )
+    def test_root_domain(self, domain, root_domain):
+        assert Domain(domain).root_domain == root_domain
+
+    def test_as_dict(self):
+        # Not really going to go to town on this just yet, the exact contents
+        # aren't used by anyone. It's just a good way to dump them right now.
+        assert Domain("www.example.com").as_dict() == Any.dict()


### PR DESCRIPTION
These came from the work for parsing the URLs from `h`'s database dump. We're probably going to need most of this when we get around to doing the admin interface, but it's going to take some time to finish, and we don't need it immediately.

~Oof 15k diff. Might need to split data from the code here.~ https://github.com/hypothesis/checkmate/pull/156

### A bit of history

There are a few main classes of things being added here:

 * This we need now for sure
 * Things I needed during the allow list scripting (which we may or may not need)
 * Things which I used during the allow list scripting which we probably don't need or have been superseded (TLD stuff might be in there, but it still seems useful)
 * Things which are bolted together to make something from the above
 * Things which are obvious extensions of the things around them

So there's definitely some fat in there which if we spent time on, we could trim out. On the other hand, we might then immediately find we want the thing we trimmed when we do something new.

### Review notes

This PR has been split into a number of PRs to make reviewing less awful:

 * [x] https://github.com/hypothesis/checkmate/pull/156 - A commit with huge data files
 * [x] https://github.com/hypothesis/checkmate/pull/157 - Core domain logic
 * [x] https://github.com/hypothesis/checkmate/pull/158 - TLD logic
 * [x] https://github.com/hypothesis/checkmate/pull/159 - Public suffix logic
 * [ ] This PR - Adding the domain interface which pulls it all together