### PR TITLE
Add specific wording and feedback options for `not-explicitly-allowed` pages

### DIFF
--- a/checkmate/templates/blocked_page.html.jinja2
+++ b/checkmate/templates/blocked_page.html.jinja2
@@ -4,7 +4,7 @@
     Content not available
 {% endblock %}
 
-{% macro how_to_access() %}
+{% macro how_to_access(request_access=False) %}
     <p>
         <strong>To view the annotations on this page:</strong>
     </p>
@@ -19,6 +19,27 @@
             <a href="{{ blocked_url | e }}" target="_blank">{{ blocked_url }}</a>
             and click on the extension icon to see the annotations.
         </li>
+        {% if request_access %}
+            {% set email_subject %}Please allow access to '{{ domain_to_annotate | e }}'{% endset %}
+            {% set email_body -%}
+I'd like to access this page with Via:
+
+ * {{ blocked_url | e }}
+
+I'd like to be able to access this site because ...
+
+    <Please give the reasons you'd like to access the site here>
+
+Thanks!
+            {%- endset %}
+            <li>
+                Or
+                <a href="mailto:via@hypothes.is?subject={{ email_subject | urlencode }}&body={{ email_body | urlencode }}" target="_blank">
+                  email us
+                </a>
+                to let us know you'd like to annotate the page with Via.
+            </li>
+        {% endif %}
     </ol>
 {% endmacro %}
 
@@ -64,6 +85,13 @@
                 right away…"
         } %}
 
+    {% elif reason == "not-explicitly-allowed" %}
+        {% set text = {
+            "heading": "Content cannot be annotated yet",
+            "details": "Unfortunately, the contents of this page cannot be
+                annotated through this Hypothesis service at this time."
+        } %}
+
     {% else %}
         {% set text = {
             "heading": "Content cannot be annotated",
@@ -83,7 +111,7 @@
         {% if reason == "malicious" %}
             {{ bad_site_ahead() }}
         {% else %}
-            {{ how_to_access() }}
+            {{ how_to_access(request_access = (reason == "not-explicitly-allowed") ) }}
         {% endif %}
     </article>
 

--- a/checkmate/views/ui/present_block.py
+++ b/checkmate/views/ui/present_block.py
@@ -1,4 +1,5 @@
 """User feedback for blocked pages."""
+from urllib.parse import urlparse
 
 from pyramid.exceptions import HTTPForbidden
 from pyramid.view import view_config
@@ -23,4 +24,10 @@ def present_block(_context, request):
 
     # At this point we know the contents of the args came from us, so we'll
     # assume that they are correct.
-    return {"blocked_url": request.GET["url"], "reason": request.GET["reason"]}
+    url_to_annotate = request.GET["url"]
+
+    return {
+        "blocked_url": url_to_annotate,
+        "domain_to_annotate": urlparse(url_to_annotate).netloc,
+        "reason": request.GET["reason"],
+    }

--- a/tests/unit/checkmate/views/ui/present_block_test.py
+++ b/tests/unit/checkmate/views/ui/present_block_test.py
@@ -11,7 +11,11 @@ class TestPresentBlock:
     def test_it_passes_through_params(self, make_request, params):
         result = present_block(sentinel.context, make_request(params=params))
 
-        assert result == {"blocked_url": params["url"], "reason": params["reason"]}
+        assert result == {
+            "blocked_url": params["url"],
+            "domain_to_annotate": "bad.example.com",  # From "url"
+            "reason": params["reason"],
+        }
 
     def test_it_checks_param_signing(self, make_request, secure_link_service, params):
         secure_link_service.is_secure.return_value = False


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/15

There's clearly some debate to be had here, but this ensures that `not-explicitly-allowed` pages have very similar wording and feedback options to the current Via solution with the following exceptions:

Email content:

 * Instead of filling out the email saying that the user would like to annotate, we give them an opportunity to explain why they want the page unblocked instead without putting words in their mouths
 * This gives the user an opportunity to reveal that they aren't interested in annotation / don't know we do annotation etc.
 * I doubt this will happen often, but it seems worth a try
 * My best guess is people will just fire it off without editing it (this might be information all by itself)
 * In the future we might want to capture things like the browser type etc to help with decisions

Request for feedback:

 * This has slightly different wording to the deployed page, mostly to show we can
 * Now there are specific variations for each major type, it's probably time to pass over to front-end folk for any further design etc.
 * The call to action for emailing us is _only_ shown on pages where the cause is `not-explicitly-allowed`
    * This matches the previous behaviour for previous categories
    * Importantly it doesn't encourage the user to request things we can't grant (publisher blocked pages)
    * ... or things we won't grant (pages we have actively chosen to block). 

If we want to allow people to report mistakes in our active (rather than passive) blocking, I think that's a separate task and may have different requirements.

## Testing notes

Not explicitly allowed:

http://localhost:9099/ui/block?url=http%3A%2F%2Fwabblewabble.com%2Fpath%3Fa%3D2&reason=not-explicitly-allowed&v=1&sec=bbb39e8f8f600a3c200feab3fc753afaa98f00ac4be4de2155f34beb330dd4c8

Malicious:

http://localhost:9099/ui/block?url=http%3A%2F%2Fbad.web.app&reason=malicious&v=1&sec=c13e01c72eaa510e28c35efec05eb608805f8ad27bf93730e77e07f2e125d483

Other:

http://localhost:9099/ui/block?url=http%3A%2F%2Fwww.youtube.com&reason=other&v=1&sec=142d0a1c44d84ac346ab2ee328f654958ec16a0bd5e85bea73f2d4ad3062a306

Publisher blocked:

http://localhost:9099/ui/block?url=http%3A%2F%2Fnautil.us&reason=publisher-blocked&v=1&sec=bdcefa4c2325326289d69d0844a7ac60b27a8603dd87d6c2dcede71e0c0e643c