### PR TITLE
Use an abstract base class for individual checkers

### DIFF
--- a/checkmate/checker/url/_hashed_url_checker.py
+++ b/checkmate/checker/url/_hashed_url_checker.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+
+class HashedURLChecker(ABC):
+    """Abstract base class for URL checkers which operate on hex hashes."""
+
+    def __init__(self, session):
+        """Create a new checking object.
+
+        :param session: A DB session to work in
+        """
+        self._session = session
+
+    @abstractmethod
+    def check_url(self, hex_hashes):
+        """Check for reasons to block a URL based on it's hashes.
+
+        :param hex_hashes: A list of hashes for a URL
+        :returns: A generator of Reason objects
+        """

--- a/checkmate/checker/url/allow_rules.py
+++ b/checkmate/checker/url/allow_rules.py
@@ -1,17 +1,10 @@
 """A checker based on our own curated allow list."""
-
+from checkmate.checker.url._hashed_url_checker import HashedURLChecker
 from checkmate.models import AllowRule, Reason
 
 
-class AllowRules:
+class AllowRules(HashedURLChecker):
     """A checker based on our own curated allow list."""
-
-    def __init__(self, session):
-        """Create a new AllowRules object.
-
-        :param session: A DB session to work in
-        """
-        self._session = session
 
     def check_url(self, hex_hashes):
         """Check to see if a URL is explicitly allowed, based on it's hashes.

--- a/checkmate/checker/url/custom_rules.py
+++ b/checkmate/checker/url/custom_rules.py
@@ -4,19 +4,13 @@ from logging import getLogger
 
 import requests
 
+from checkmate.checker.url._hashed_url_checker import HashedURLChecker
 from checkmate.models import CustomRule, Reason
 from checkmate.url import hash_for_rule
 
 
-class CustomRules:
+class CustomRules(HashedURLChecker):
     """A checker based on our own curated ruleset."""
-
-    def __init__(self, session):
-        """Create a new CustomRules object.
-
-        :param session: A DB session to work in
-        """
-        self._session = session
 
     def check_url(self, hex_hashes):
         """Check for reasons to block a URL based on it's hashes.

--- a/checkmate/checker/url/url_haus.py
+++ b/checkmate/checker/url/url_haus.py
@@ -3,11 +3,12 @@
 from tempfile import TemporaryDirectory
 
 from checkmate.checker.pipeline import Download, Pipeline, ReadCSVFile, UnzipFile
+from checkmate.checker.url._hashed_url_checker import HashedURLChecker
 from checkmate.models import Reason, URLHausRule
 from checkmate.url import hash_for_rule
 
 
-class URLHaus:
+class URLHaus(HashedURLChecker):
     """A checker which works against and updates URLHaus rules."""
 
     # The columns provided in the CSV from URLHaus are:
@@ -29,13 +30,6 @@ class URLHaus:
             ReadCSVFile(),
         ]
     )
-
-    def __init__(self, session):
-        """Create a new URLHaus object.
-
-        :param session: A DB session to work in
-        """
-        self._session = session
 
     def check_url(self, hex_hashes):
         """Check for reasons to block a URL based on it's hashes.


### PR DESCRIPTION
Based on feedback in some recent reviews, there's a slight oddity that one checker has a different interface to the others.

This PR makes the ones that are the same have exactly the same interface. There's another PR to make the odd one out a service instead.