### PR TITLE
Compound checker as service

### DIFF
--- a/checkmate/checker/url/__init__.py
+++ b/checkmate/checker/url/__init__.py
@@ -1,4 +1,3 @@
 from checkmate.checker.url.allow_rules import AllowRules
-from checkmate.checker.url.compound_rules import CompoundRules
 from checkmate.checker.url.custom_rules import CustomRules
 from checkmate.checker.url.url_haus import URLHaus

--- a/checkmate/models/source.py
+++ b/checkmate/models/source.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class Source(Enum):
+    """An enum for the places a rule hit can come from."""
+
+    URL_HAUS = "url_haus"
+    BLOCK_LIST = "block_list"
+    ALLOW_LIST = "allow_list"

--- a/checkmate/services/__init__.py
+++ b/checkmate/services/__init__.py
@@ -1,8 +1,11 @@
 from checkmate.services.secure_link import SecureLinkService
+from checkmate.services.url_checker import URLCheckerService
 
 
 def includeme(config):  # pragma: no cover
     config.register_service_factory(
-        "checkmate.services.secure_link.factory",
-        iface=SecureLinkService,
+        "checkmate.services.secure_link.factory", iface=SecureLinkService
+    )
+    config.register_service_factory(
+        "checkmate.services.url_checker.factory", iface=URLCheckerService
     )

--- a/checkmate/services/url_checker.py
+++ b/checkmate/services/url_checker.py
@@ -1,33 +1,34 @@
 from operator import attrgetter
 
-from checkmate.checker.url.allow_rules import AllowRules
-from checkmate.checker.url.custom_rules import CustomRules
-from checkmate.checker.url.url_haus import URLHaus
+from checkmate.checker.url import AllowRules, CustomRules, URLHaus
 from checkmate.models import Severity
+from checkmate.models.source import Source
 from checkmate.url import hash_url
 
 
-class CompoundRules:
+class URLCheckerService:
     """A wrapper around other checking rules."""
 
-    def __init__(self, db_session, allow_all=False, fail_fast=True):
+    def __init__(self, db_session):
         """Create a new CompoundRules object.
 
         :param db_session: A DB session to work in
-        :param allow_all: Disable the allow list protection
-        :param fail_fast: Stop at the first mandatory reason we get
         """
         self._db_session = db_session
-        self._fail_fast = fail_fast
+        self._blocking_checkers = {
+            Source.URL_HAUS: URLHaus(db_session),
+            Source.BLOCK_LIST: CustomRules(db_session),
+        }
+        self._allowing_checkers = {
+            Source.ALLOW_LIST: AllowRules(db_session),
+        }
 
-        self._checkers = [URLHaus, CustomRules]
-        if not allow_all:
-            self._checkers.append(AllowRules)
-
-    def check_url(self, url):
+    def check_url(self, url, allow_all=False, fail_fast=True):
         """Check for reasons to block a URL based on it's hashes.
 
         :param url: URL to check
+        :param allow_all: Disable the allow list protection
+        :param fail_fast: Stop at the first mandatory reason we get
         :returns: A generator of Reason objects (most severe first)
         """
 
@@ -36,16 +37,22 @@ class CompoundRules:
         # Use a set to weed out repeated identifications
         reasons = set()
 
-        for checker in self._checkers:
-            reasons.update(checker(self._db_session).check_url(url_hashes))
+        for _source, checker in self._get_checkers(allow_all):
+            reasons.update(checker.check_url(url_hashes))
 
             # We don't need to keep searching the database if we've already
             # been told this is a mandatory block
-            if self._fail_fast and self._has_mandatory(reasons):
+            if fail_fast and self._has_mandatory(reasons):
                 break
 
         # Sort the reasons by worst first
         return reversed(sorted(reasons, key=attrgetter("severity")))
+
+    def _get_checkers(self, allow_all):
+        yield from self._blocking_checkers.items()
+
+        if not allow_all:
+            yield from self._allowing_checkers.items()
 
     @classmethod
     def _has_mandatory(cls, reasons):
@@ -54,3 +61,7 @@ class CompoundRules:
                 return True
 
         return False
+
+
+def factory(_context, request):
+    return URLCheckerService(db_session=request.db)

--- a/checkmate/views/api/check_url.py
+++ b/checkmate/views/api/check_url.py
@@ -3,9 +3,8 @@
 from pyramid.httpexceptions import HTTPNoContent
 from pyramid.view import view_config
 
-from checkmate.checker.url import CompoundRules
 from checkmate.exceptions import BadURLParameter
-from checkmate.services import SecureLinkService
+from checkmate.services import SecureLinkService, URLCheckerService
 
 
 @view_config(route_name="check_url", renderer="json")
@@ -17,8 +16,8 @@ def check_url(request):
     except KeyError as err:
         raise BadURLParameter("url", "Parameter 'url' is required") from err
 
-    checker = CompoundRules(request.db, allow_all=request.GET.get("allow_all"))
-    reasons = list(checker.check_url(url))
+    url_checker = request.find_service(URLCheckerService)
+    reasons = list(url_checker.check_url(url, allow_all=request.GET.get("allow_all")))
 
     if not reasons:
         # If everything is fine give a 204 which is successful, but has no body

--- a/tests/unit/checkmate/services/url_checker_test.py
+++ b/tests/unit/checkmate/services/url_checker_test.py
@@ -1,49 +1,47 @@
+from unittest.mock import sentinel
+
 import pytest
 from h_matchers import Any
 
-from checkmate.checker.url import CompoundRules
 from checkmate.models import Reason
+from checkmate.services.url_checker import URLCheckerService, factory
 from checkmate.url import hash_url
 
 
-class TestCompoundRules:
-    def test_it_calls_sub_checkers(self, db_session, URLHaus, CustomRules, AllowRules):
+class TestURLCheckerService:
+    def test_it_calls_sub_checkers(self, checker, URLHaus, CustomRules, AllowRules):
         URLHaus.return_value.check_url.return_value = (Reason.NOT_ALLOWED,)
         CustomRules.return_value.check_url.return_value = (Reason.MALICIOUS,)
         AllowRules.return_value.check_url.return_value = (Reason.NOT_ALLOWED,)
 
-        rules = CompoundRules(db_session, fail_fast=False)
-        results = rules.check_url("http://example.com")
+        results = checker.check_url("http://example.com", fail_fast=False)
 
         # Deduped and sorted worst first
         assert list(results) == [Reason.MALICIOUS, Reason.NOT_ALLOWED]
 
         url_hashes = list(hash_url("http://example.com"))
 
-        for checker in (URLHaus, CustomRules, AllowRules):
-            checker.assert_called_once_with(db_session)
-            checker.return_value.check_url.assert_called_once_with(url_hashes)
+        for sub_checker in (URLHaus, CustomRules, AllowRules):
+            sub_checker.return_value.check_url.assert_called_once_with(url_hashes)
 
-    def test_it_can_fail_fast(self, db_session, URLHaus, CustomRules, AllowRules):
+    def test_it_can_fail_fast(self, checker, URLHaus, CustomRules, AllowRules):
         URLHaus.return_value.check_url.return_value = (Reason.MALICIOUS,)
 
-        rules = CompoundRules(db_session, fail_fast=True)
-        results = rules.check_url("http://example.com")
+        results = checker.check_url("http://example.com", fail_fast=True)
 
         assert list(results) == [Reason.MALICIOUS]
 
-        CustomRules.assert_not_called()
-        AllowRules.assert_not_called()
+        CustomRules.return_value.check_url.assert_not_called()
+        AllowRules.return_value.check_url.assert_not_called()
 
     def test_it_only_fails_fast_for_mandatory(
-        self, db_session, URLHaus, CustomRules, AllowRules
+        self, checker, URLHaus, CustomRules, AllowRules
     ):
         URLHaus.return_value.check_url.return_value = (Reason.OTHER,)
         CustomRules.return_value.check_url.return_value = (Reason.HIGH_IO,)
         AllowRules.return_value.check_url.return_value = (Reason.NOT_ALLOWED,)
 
-        rules = CompoundRules(db_session, fail_fast=True)
-        results = rules.check_url("http://example.com")
+        results = checker.check_url("http://example.com", fail_fast=True)
 
         assert (
             list(results)
@@ -53,21 +51,24 @@ class TestCompoundRules:
         )
 
     def test_it_can_disable_the_allow_list(
-        self, db_session, URLHaus, CustomRules, AllowRules
+        self, checker, URLHaus, CustomRules, AllowRules
     ):
         AllowRules.return_value.check_url.return_value = (Reason.NOT_ALLOWED,)
 
-        rules = CompoundRules(db_session, allow_all=True, fail_fast=False)
-        rules.check_url("http://example.com")
+        checker.check_url("http://example.com", allow_all=True, fail_fast=False)
 
-        AllowRules.assert_not_called()
+        AllowRules.return_value.check_url.assert_not_called()
+
+    @pytest.fixture
+    def checker(self, db_session):
+        return URLCheckerService(db_session)
 
     @pytest.fixture
     def patch_checker(self, patch):
         """Return a function for patching a checker class."""
 
         def patch_checker(checker_class):
-            checker_cls = patch(f"checkmate.checker.url.compound_rules.{checker_class}")
+            checker_cls = patch(f"checkmate.services.url_checker.{checker_class}")
             checker_cls.return_value.check_url.return_value = tuple()
             return checker_cls
 
@@ -84,3 +85,11 @@ class TestCompoundRules:
     @pytest.fixture(autouse=True)
     def URLHaus(self, patch_checker):
         return patch_checker("URLHaus")
+
+
+class TestFactory:
+    # Some basic sanity
+    def test_it(self, pyramid_request):
+        service = factory(sentinel.context, pyramid_request)
+
+        assert isinstance(service, URLCheckerService)

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+from checkmate.services import URLCheckerService
 from checkmate.services.secure_link import SecureLinkService
 
 
@@ -19,3 +20,8 @@ def mock_service(pyramid_config):
 @pytest.fixture
 def secure_link_service(mock_service):
     return mock_service(SecureLinkService)
+
+
+@pytest.fixture
+def url_checker_service(mock_service):
+    return mock_service(URLCheckerService)


### PR DESCRIPTION
Based on some feedback in previous reviews, the "CompoundChecker" has been converted into a pyramid services service as "URLChecker". 

This resolves some interface oddness, and clarifies why it has a different interface from the pure python checking classes.