### PR TITLE
Disable custom hex and bin IP addresses format

### DIFF
--- a/checkmate/url/canonicalize.py
+++ b/checkmate/url/canonicalize.py
@@ -153,22 +153,9 @@ class CanonicalURL:
 
         return path or "/"
 
-    HEX_DOT_IP = re.compile(r"^[0-f]+\.[0-f]+\.[0-f]+\.[0-f]+$", re.IGNORECASE)
-    BINARY_DOT_IP = re.compile(r"^[01]+\.[01]+\.[01]+\.[01]+$", re.IGNORECASE)
-
     @classmethod
     def _decode_ip(cls, hostname):
         """Try and spot hostnames that are really encoded IP addresses."""
-        if cls.HEX_DOT_IP.match(hostname):
-            decoded = cls._decode_ip("0x" + hostname.replace(".", ""))
-
-            if decoded:
-                return decoded
-
-        if cls.BINARY_DOT_IP.match(hostname):
-            parts = [str(int(part, 2)) for part in hostname.split(".")]
-            return ".".join(parts)
-
         try:
             return str(IPAddress(hostname))
         except AddrFormatError:

--- a/tests/unit/checkmate/url/canonicalise_test.py
+++ b/tests/unit/checkmate/url/canonicalise_test.py
@@ -62,6 +62,14 @@ class TestCanonicalURL:
             ("http://030337600013/blah", "http://195.127.0.11/blah"),
             ("http://0xc3.0x7f.0x00.0x0b/blah", "http://195.127.0.11/blah"),
             ("http://0xc37f000b/blah", "http://195.127.0.11/blah"),
+            ("http://192.168.2.1/uploads/", "http://192.168.2.1/uploads/"),
+            ("http://0x7F.0.0.1/uploads/", "http://127.0.0.1/uploads/"),
+            ("http://0x7F.0.0.0x1/uploads/", "http://127.0.0.1/uploads/"),
+            ("http://10.0.0.1/uploads/", "http://10.0.0.1/uploads/"),
+            (
+                "http://022.101.31.153/uploads/",
+                "http://18.101.31.153/uploads/",
+            ),  # Leading 0 as octal
             # Punycode testing (added by us)
             ("http://ümlaut.com", "http://xn--mlaut-jva.com/"),
             # Some unspecified behavior around badly formatted URLs (added by


### PR DESCRIPTION
Only 0x (hex) and 0 (oct) prefixed seems to be supported by chrome and netaddr.IPAddress understands those fine.

My "fix" just removing the hex and bin regexp code, added a few extra test cases and checked the behavior in chrome.

https://en.wikipedia.org/wiki/Dot-decimal_notation suggest this is not very  standardized