### PR TITLE
Add a Detection object with source and change the checker to return it

### DIFF
--- a/checkmate/models/__init__.py
+++ b/checkmate/models/__init__.py
@@ -3,7 +3,9 @@
 from checkmate.models.db.allow_rule import AllowRule
 from checkmate.models.db.custom_rule import CustomRule
 from checkmate.models.db.url_haus_rule import URLHausRule
+from checkmate.models.detection import Detection
 from checkmate.models.reason import Reason, Severity
+from checkmate.models.source import Source
 
 
 def includeme(_config):  # pragma: no cover

--- a/checkmate/models/detection.py
+++ b/checkmate/models/detection.py
@@ -1,0 +1,36 @@
+from checkmate.models.reason import Reason
+from checkmate.models.source import Source
+
+
+class Detection:
+    """A model for a detection in our rulesets."""
+
+    def __init__(self, reason, source):
+        """Create a new rule detection object.
+
+        :param reason: Reason object for why this detection happened
+        :param source: Source onject for where this detection came from
+        """
+        assert isinstance(reason, Reason)
+        assert isinstance(source, Source)
+
+        self.reason = reason
+        self.source = source
+
+    @property
+    def severity(self):
+        """Get how bad this detection is.
+
+        :rtype: Severity
+        """
+
+        return self.reason.severity
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.reason}, {self.source})"
+
+    def __eq__(self, other):
+        if not isinstance(other, Detection):
+            return False
+
+        return (other.reason, other.source) == (self.reason, self.source)

--- a/tests/unit/checkmate/models/detection_test.py
+++ b/tests/unit/checkmate/models/detection_test.py
@@ -1,0 +1,46 @@
+import pytest
+
+from checkmate.models import Reason, Source
+from checkmate.models.detection import Detection
+
+
+class TestDetection:
+    @pytest.mark.parametrize(
+        "reason,source", ((Reason.OTHER, "bad"), ("bad", Source.URL_HAUS))
+    )
+    def test_it_explodes_with_bad_inputs(self, reason, source):
+        with pytest.raises(AssertionError):
+            Detection(reason, source)
+
+    @pytest.mark.parametrize(
+        "reason",
+        (
+            Reason.OTHER,
+            Reason.MALICIOUS,
+        ),
+    )
+    def test_it_passes_through_severity(self, reason):
+        detection = Detection(reason, Source.URL_HAUS)
+
+        assert detection.severity == reason.severity
+
+    @pytest.mark.parametrize(
+        "other,equal",
+        (
+            (Detection(Reason.MALICIOUS, Source.URL_HAUS), True),
+            (Detection(Reason.MALICIOUS, Source.ALLOW_LIST), False),
+            (Detection(Reason.OTHER, Source.URL_HAUS), False),
+            ("not_a_detection", False),
+        ),
+    )
+    def test_equals(self, other, equal):
+        detection = Detection(Reason.MALICIOUS, Source.URL_HAUS)
+
+        assert (detection == other) == equal
+
+    def test_repr(self):
+        detection = Detection(Reason.MALICIOUS, Source.URL_HAUS)
+
+        assert "Detection" in repr(detection)
+        assert "MALICIOUS" in repr(detection)
+        assert "URL_HAUS" in repr(detection)

--- a/tests/unit/checkmate/views/api/check_url_test.py
+++ b/tests/unit/checkmate/views/api/check_url_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from checkmate.exceptions import BadURLParameter, MalformedURL
-from checkmate.models import Reason
+from checkmate.models import Detection, Reason, Source
 from checkmate.views.api.check_url import check_url
 
 
@@ -25,8 +25,9 @@ class TestURLCheck:
 
     def test_a_bad_url(self, make_request, url_checker_service, secure_link_service):
         url_checker_service.check_url.return_value = (
-            Reason.MALICIOUS,
-            Reason.MEDIA_IMAGE,
+            Detection(Reason.MALICIOUS, Source.URL_HAUS),
+            Detection(Reason.MEDIA_IMAGE, Source.BLOCK_LIST),
+            Detection(Reason.MEDIA_IMAGE, Source.BLOCK_LIST),
         )
         bad_url = "http://sad.example.com"
 


### PR DESCRIPTION
This now returns 'Detections' rather than just 'Reasons' which include the source. This means the view has to do a little more work for the same output, but means we can pass this info along in future.

This is intended to be used in a different end-point for the admin pages only.