### PR TITLE
Configure logging for development

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -5,3 +5,25 @@ dev = true
 
 [pshell]
 setup = checkmate.pshell.setup
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[handler_console]
+level = NOTSET
+class = StreamHandler
+args = ()
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s [%(process)d] [%(name)s:%(levelname)s] %(message)s


### PR DESCRIPTION
I wanted to do logging in a different branch and I'd say something like this might be necessary.

Copied mostly from the h repo: https://github.com/hypothesis/h/blob/master/conf/development-app.ini#L34 but there might be a good reason to not having it in checkmate.


