### PR TITLE
Change CSS + block page to reflect changes and wording in Via

### DIFF
--- a/checkmate/static/static/css/wrapper-style.css
+++ b/checkmate/static/static/css/wrapper-style.css
@@ -1,130 +1,57 @@
-/**
-* Eric Meyer's Reset CSS v2.0 (http://meyerweb.com/eric/tools/css/reset/)
-* http://cssreset.com
-*/
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-}
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
   display: block;
 }
-body {
-  line-height: 1;
-}
-ol, ul {
-  list-style: none;
-}
-blockquote, q {
-  quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-  content: '';
-  content: none;
-}
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
 
-/* page style */
+/* Basic element styling */
+
 body {
+  line-height: 1.5;
   background-color: #ececec;
-  margin: 0 auto;
   color: #333333;
-  max-width: 960px;
   font-family: 'Source Sans Pro', sans-serif;
   -webkit-font-smoothing: antialiased;
-  text-align: center;
-}
 
-header {
-  padding: 100px 0 0 0;
-}
-
-header, article {
-  text-align: left;
   margin: 0 auto;
   max-width: 600px;
 }
 
 p, ol {
   font-size: 20px;
-  line-height: 27px;
-  padding-bottom: 30px;
-  max-width: 600px;
-  margin: 0 auto;
 }
 
-strong {
-  font-weight: 700;
-}
-
-h1 {
-  font-weight: 700;
-  font-size: 20px;
-  line-height: 27px;
-}
-
-p a, li a {
-  border-bottom: 1px solid #DCDCDC;
-  text-decoration: none;
+a {
   color: #333333;
-}
-
-ol {
-  list-style-type: decimal;
-  padding-left: 17px;
-}
-
-ol li {
-  font-size: 20px;
-  line-height: 27px;
-  padding-bottom: 30px;
 }
 
 a:hover {
-  color: #333333;
+  color: #000000;
+}
+
+/* Major page chunks */
+
+header {
+  padding: 40px 0 0 0;
+}
+
+article > p:first-child {
+  padding-bottom: 20px;
 }
 
 footer {
-  padding: 90px 0;
+  padding: 70px 0;
+  text-align: center;
 }
 
 #footer-logo {
-  display:inline-block;
+  display: inline-block;
   width: 24px;
-  height:28px;
+  height: 28px;
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAA4CAQAAAARWLNhAAABgUlEQVR42u2Yz0rDQBDGhwpKe6wUSXspepE+gGfv+gCtPaTv4EMIHrx7K0iepILXmQ2btAQECYmXnoSWStUYxNLdNmoKsyCab2677P6WbybZPwAwapCDESbMEZEzasDH9GP2yT+DxikiXX1iLsgBA+ZoRoHR6dMoAJsDQBHOC0ABKAB/APCCUzwX+3I7Kfm78kic4Q3NWAFkw4rcA7xlA9AAMhSWacAEcI8hU34zv1HfAr4WXhsGuCdMADwlF6c0o3txEewogD0WgDikZ+UIcrnsSbbojaNMr7QzzoNWYU8cZXqnAV6TEjfgUe8Ly8wAnJgGzP8PgELqeJZnUYdCAwAKZXXRLqs6ggfQ1mqvzQ7wLHWUZ7EDhnV11LDODhBd7Q/W5a+iKKgt2oOafin7adPP+x3EZPvNdKezMS6uUL8PYPoibvwpwfhjiPHnnDyifub6+sCluIJyDSDjCvBJtlYOABPZAl6JngoQPeDXMhOM7mdmgtf9tUzwu69nYlP33wEjM9swn4BymAAAAABJRU5ErkJggg==);
   background-size: 24px 28px;
 
   font-size:0;
-}
-
-@media (max-width: 800px) {
-  body {padding: 2em 1em;}
-  header {padding: 50px 0; font-size: 36px; line-height: 42px;}
-  h1 {font-size: 48px; line-height: 48px;}
-  p, ol li {font-size: 18px; line-height: 24px;}
 }
 
 /* Add exceptions for malicious view */
@@ -140,7 +67,25 @@ footer {
 }
 
 body.danger {
-  color:white;
+  color: white;
   background-color: #aa0000;
 }
 
+/* Responsive design */
+
+@media (max-width: 800px) {
+  body {
+    padding: 1em 1em;
+  }
+  header {
+    line-height: 1;
+    padding: 0;
+    font-size: 36px;
+  }
+  h1 {
+    font-size: 48px;
+  }
+  p, li {
+    font-size: 18px;
+  }
+}

--- a/checkmate/templates/blocked_page.html.jinja2
+++ b/checkmate/templates/blocked_page.html.jinja2
@@ -5,13 +5,13 @@
 {% endblock %}
 
 {% macro how_to_access(request_access=False) %}
-    <p>
-        <strong>To view the annotations on this page:</strong>
-    </p>
+    <h2>To annotate this page</h2>
+
+    <h3>Use our browser extension:</h3>
 
     <ol>
         <li>
-            Follow the <a href="https://web.hypothes.is/" target="_blank">instructions
+            Follow the <a href="https://web.hypothes.is/start/" target="_blank">instructions
             on our homepage</a> to install our browser extension.
         </li>
         <li>
@@ -19,28 +19,31 @@
             <a href="{{ blocked_url | e }}" target="_blank">{{ blocked_url }}</a>
             and click on the extension icon to see the annotations.
         </li>
-        {% if request_access %}
-            {% set email_subject %}Please allow access to '{{ domain_to_annotate | e }}'{% endset %}
-            {% set email_body -%}
+
+    </ol>
+
+    {% if request_access %}
+        <h3>Or get in contact:</h3>
+
+        {% set email_subject %}Please allow access to '{{ domain_to_annotate | e }}'{% endset %}
+        {% set email_body -%}
 I'd like to access this page with Via:
 
- * {{ blocked_url | e }}
+* {{ blocked_url | e }}
 
 I'd like to be able to access this site because ...
 
-    <Please give the reasons you'd like to access the site here>
+<Please give the reasons you'd like to access the site here>
 
 Thanks!
-            {%- endset %}
-            <li>
-                Or
-                <a href="mailto:via@hypothes.is?subject={{ email_subject | urlencode }}&body={{ email_body | urlencode }}" target="_blank">
-                  email us
-                </a>
-                to let us know you'd like to annotate the page with Via.
-            </li>
-        {% endif %}
-    </ol>
+        {%- endset %}
+        <p>
+            <a href="mailto:via@hypothes.is?subject={{ email_subject | urlencode }}&body={{ email_body | urlencode }}" target="_blank"
+            >Email us</a>
+            to let us know you'd like to annotate the page with Via.
+        </p>
+    {% endif %}
+
 {% endmacro %}
 
 {% macro bad_site_ahead() %}


### PR DESCRIPTION
This imports some wording and layout changes made in Via but not in ViaHTML. This also tries to simplify the CSS and page layout.

Layout changes:

 * Stopped including the email us as if it's a 3rd step in an ordered list
 * We have a separate section for this now with it's own heading away from the instructions to install the browser extension
 * We had a mess of nested lists which looked weird
 * We also had bolded paragraphs instead of headings
 * This has been replaced with nested `h1 > h2 > h3` - This should also help with accessibility.

Radically simplified the CSS:

This had a CSS "reset" at the top which seemed to radically change the normal CSS defaults you'd expect in a browser. We then spent a lot of CSS putting them back in in one way or another. Styled a lot of elements we don't have.

In particular we set line-height:1 and then went and set every element to have a line height 1.5 times the font-size. We also used borders rather than let the links use regular link underlining.

Basically we have a lot less CSS fighting itself and it looks more like a normal page.

### Review notes

I'm pretty sure this won't stand for long. This is all getting ripped out real soon.

I've separated out two PRs. The first one has the Via / "Hypothesis service" wording changes as there was some debate. We could easily skip this if people prefer the old wording.