### PR TITLE
Add support for downloading dev data for env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.devdata.env
 .coverage*
 .tox
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,9 @@ sql: python
 
 .PHONY: devdata
 devdata: python
-	@tox -qe dev --run-command 'devdata conf/development.ini'  # See setup.py for what devdata is.
+	# See setup.py for what devdata and devdata-remote are.
+	@tox -qe dev --run-command 'devdata-remote'
+	@tox -qe dev --run-command 'devdata conf/development.ini'
 
 .PHONY: lint
 lint: python

--- a/checkmate/scripts.py
+++ b/checkmate/scripts.py
@@ -6,9 +6,13 @@ To use run:
  * initdb conf/development.ini
  * devdata conf/development.ini
 """
-
+import os
+import shutil
+import subprocess
 import sys
+from tempfile import TemporaryDirectory
 
+from pkg_resources import resource_filename
 from pyramid.paster import bootstrap
 
 from checkmate.checker.url.custom_rules import CustomRules
@@ -30,6 +34,28 @@ def update_dev_data():
             }
             CustomRules(request.db).load_simple_rules(raw_rules)
             print(f"Loaded {len(raw_rules)} custom rules")
+
+
+def update_remote_dev_data():
+    """Get secrets and data stored in the devdata repo."""
+
+    with TemporaryDirectory() as git_dir:
+        subprocess.check_call(
+            [
+                "git",
+                "clone",
+                "git@github.com:hypothesis/devdata.git",
+                git_dir,
+                # Truncate the git history, we just want the files
+                "--depth=1",
+            ]
+        )
+
+        # Copy devdata env file into place.
+        shutil.copyfile(
+            os.path.join(git_dir, "checkmate", "devdata.env"),
+            resource_filename("checkmate", "../.devdata.env"),
+        )
 
 
 def initialize_db():

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     entry_points="""\
     [console_scripts]
     devdata = checkmate.scripts:update_dev_data
+    devdata-remote = checkmate.scripts:update_remote_dev_data
     initdb = checkmate.scripts:initialize_db
     """,
 )


### PR DESCRIPTION
Trying to hack bits off of: https://github.com/hypothesis/checkmate/pull/173

This just does the downloading of env vars from dev-data. They won't be used yet.