### PR TITLE
Add missing library required for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache --virtual \
     build-deps \
     build-base \
     postgresql-dev \
+    libffi-dev \
   && pip install --no-cache-dir -U pip \
   && pip install --no-cache-dir -r requirements.txt \
   && apk del build-deps


### PR DESCRIPTION
Looks like we need `cffi` as a result of some of the Google auth requirements.

## Testing notes

`make docker`