### PR TITLE
Enable tox's sitepackages based on enviroment variable

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,8 @@ commands =
     tests: coverage report
     dockercompose: docker-compose {posargs}
 
+sitepackages = {env:SITE_PACKAGES:false}
+
 [testenv:dev]
 # By default when you Ctrl-c the `make dev` command tox is too aggressive about
 # killing supervisor. tox kills supervisor before supervisor has had time to


### PR DESCRIPTION
Jenkins files is already setting said variable to true but it was not read from tox.