### PR TITLE
Add an authorization policy

### DIFF
--- a/checkmate/app.py
+++ b/checkmate/app.py
@@ -5,10 +5,9 @@ import re
 
 import pyramid.config
 import pyramid_tm
-from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.session import SignedCookieSessionFactory
 
-from checkmate.authentication import AuthenticationPolicy
+from checkmate.auth import AuthenticationPolicy, AuthorizationPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +23,7 @@ class CheckmateConfigurator:
         self._configure_db(config)
         self._configure_sentry(config)
         if not celery_worker:
-            self._configure_authentication(config)
+            self._configure_auth(config)
 
         self._configure_checkmate(config)
 
@@ -103,7 +102,7 @@ class CheckmateConfigurator:
 
         config.include("h_pyramid_sentry")
 
-    def _configure_authentication(self, config):
+    def _configure_auth(self, config):
         # This is used here, but also by the Signature service
         checkmate_secret = self.add_setting_from_env("checkmate_secret")
 
@@ -126,9 +125,7 @@ class CheckmateConfigurator:
         config.set_session_factory(session_factory)
 
         config.set_authentication_policy(AuthenticationPolicy())
-
-        # We don't use ACLs, but pyramid needs an authorization policy anyway
-        config.set_authorization_policy(ACLAuthorizationPolicy())
+        config.set_authorization_policy(AuthorizationPolicy())
 
     @classmethod
     def _get_api_keys_from_env(cls):

--- a/checkmate/auth.py
+++ b/checkmate/auth.py
@@ -5,8 +5,9 @@ from pyramid.authentication import (
     SessionAuthenticationPolicy,
     extract_http_basic_credentials,
 )
+from pyramid.security import Allowed, Denied
 
-from checkmate.models import Principals
+from checkmate.models import Permissions, Principals
 
 
 class CascadingAuthenticationPolicy:
@@ -138,3 +139,14 @@ class APIHTTPAuth(BasicAuthAuthenticationPolicy):
             return [Principals.API]
 
         return None
+
+
+class AuthorizationPolicy:
+    """Checkmate's custom Pyramid authorization policy."""
+
+    @staticmethod
+    def permits(_context, principals, permission):
+        if permission == Permissions.CHECK_URL and Principals.API in principals:
+            return Allowed("allowed")
+
+        return Denied("denied")

--- a/checkmate/models/__init__.py
+++ b/checkmate/models/__init__.py
@@ -1,10 +1,10 @@
 """Data and domain models."""
 
+from checkmate.models.auth import Permissions, Principals
 from checkmate.models.db.allow_rule import AllowRule
 from checkmate.models.db.custom_rule import CustomRule
 from checkmate.models.db.url_haus_rule import URLHausRule
 from checkmate.models.detection import Detection
-from checkmate.models.principals import Principals
 from checkmate.models.reason import Reason, Severity
 from checkmate.models.source import Source
 

--- a/checkmate/models/auth.py
+++ b/checkmate/models/auth.py
@@ -1,3 +1,5 @@
+"""Pyramid authentication-related models."""
+
 from enum import Enum
 
 
@@ -17,3 +19,9 @@ class Principals(Enum):
             return (Principals.STAFF,)
 
         return None
+
+
+class Permissions(Enum):
+    """Security permissions."""
+
+    CHECK_URL = "check_url"

--- a/checkmate/views/api/check_url.py
+++ b/checkmate/views/api/check_url.py
@@ -1,17 +1,14 @@
 """URL checking."""
 
-from pyramid.httpexceptions import HTTPNoContent, HTTPUnauthorized
-from pyramid.security import forget
+from pyramid.httpexceptions import HTTPNoContent
 from pyramid.view import view_config
 
 from checkmate.exceptions import BadURLParameter, MalformedURL
-from checkmate.models import Principals
+from checkmate.models import Permissions
 from checkmate.services import SecureLinkService, URLCheckerService
 
 
-@view_config(
-    route_name="check_url", renderer="json", effective_principals=Principals.API
-)
+@view_config(route_name="check_url", renderer="json", permission=Permissions.CHECK_URL)
 def check_url(request):
     """Check a given URL for any reasons we might want to block it."""
 
@@ -59,10 +56,3 @@ def check_url(request):
             )
         },
     }
-
-
-@view_config(route_name="check_url")
-def check_url_unauthorized(request):
-    response = HTTPUnauthorized()
-    response.headers.update(forget(request))
-    return response

--- a/checkmate/views/api/exception.py
+++ b/checkmate/views/api/exception.py
@@ -1,6 +1,6 @@
 """API exception views."""
 
-from pyramid.view import exception_view_config
+from pyramid.view import exception_view_config, forbidden_view_config
 
 from checkmate.exceptions import JSONAPIException
 
@@ -11,3 +11,9 @@ def api_error(exc, request):
     request.response.status_code = exc.status_code
 
     return {"errors": [exc.serialise()]}
+
+
+@forbidden_view_config(path_info="^/api/.*$", renderer="json")
+def api_forbidden(context, request):
+    request.response.status_int = context.status_int
+    return {"error": "invalid_token"}

--- a/checkmate/views/ui/api/login.py
+++ b/checkmate/views/ui/api/login.py
@@ -6,7 +6,7 @@ from pyramid.httpexceptions import HTTPFound
 from pyramid.security import forget, remember
 from pyramid.view import view_config
 
-from checkmate.authentication import GoogleAuthenticationPolicy
+from checkmate.auth import GoogleAuthenticationPolicy
 from checkmate.exceptions import UserNotAuthenticated
 from checkmate.services import GoogleAuthService
 

--- a/tests/functional/checkmate/views/api/check_url_test.py
+++ b/tests/functional/checkmate/views/api/check_url_test.py
@@ -1,15 +1,15 @@
 class TestAPIAuth:
-    def test_401_unauthenticated(self, app):
+    def test_403_forbidden(self, app):
         res = app.get("/api/check", expect_errors=True)
 
-        assert res.status_code == 401
+        assert res.status_code == 403
 
-    def test_401_unauthenticated_no_matching_users(self, app):
+    def test_403_forbidden_no_matching_users(self, app):
         app.authorization = ("Basic", ("api_nonsense",))
 
         res = app.get("/api/check", expect_errors=True)
 
-        assert res.status_code == 401
+        assert res.status_code == 403
 
     def test_authenticated_existing_user(self, app):
         app.authorization = ("Basic", ("dev_api_key", ""))

--- a/tests/unit/checkmate/auth/api_auth_test.py
+++ b/tests/unit/checkmate/auth/api_auth_test.py
@@ -7,7 +7,7 @@ import pytest
 from pyramid.authentication import HTTPBasicCredentials
 
 from checkmate.app import CheckmateConfigurator
-from checkmate.authentication import APIHTTPAuth
+from checkmate.auth import APIHTTPAuth
 from checkmate.models import Principals
 
 
@@ -60,4 +60,4 @@ class TestAPIAuth:
 
     @pytest.fixture
     def extract_http_basic_credentials(self, patch):
-        return patch("checkmate.authentication.extract_http_basic_credentials")
+        return patch("checkmate.auth.extract_http_basic_credentials")

--- a/tests/unit/checkmate/models/auth_test.py
+++ b/tests/unit/checkmate/models/auth_test.py
@@ -2,7 +2,7 @@ from unittest.mock import sentinel
 
 import pytest
 
-from checkmate.models.principals import Principals
+from checkmate.models.auth import Principals
 
 
 class TestPrincipals:

--- a/tests/unit/checkmate/views/api/check_url_test.py
+++ b/tests/unit/checkmate/views/api/check_url_test.py
@@ -2,7 +2,7 @@ import pytest
 
 from checkmate.exceptions import BadURLParameter, MalformedURL
 from checkmate.models import Detection, Reason, Source
-from checkmate.views.api.check_url import check_url, check_url_unauthorized
+from checkmate.views.api.check_url import check_url
 
 
 @pytest.mark.usefixtures("secure_link_service", "url_checker_service")
@@ -66,11 +66,3 @@ class TestURLCheck:
 
         with pytest.raises(BadURLParameter):
             check_url(request)
-
-    def test_it_errors_if_the_request_is_unauthorized(
-        self, make_request, url_checker_service
-    ):
-        request = make_request("/api/check", {"url": "http://example.com"})
-        response = check_url_unauthorized(request)
-
-        assert response.status_code == 401

--- a/tests/unit/checkmate/views/api/exception_test.py
+++ b/tests/unit/checkmate/views/api/exception_test.py
@@ -1,9 +1,10 @@
 from unittest.mock import create_autospec
 
 import pytest
+from pyramid.httpexceptions import HTTPForbidden
 
 from checkmate.exceptions import JSONAPIException
-from checkmate.views.api.exception import api_error
+from checkmate.views.api.exception import api_error, api_forbidden
 
 
 class TestAPIError:
@@ -18,3 +19,11 @@ class TestAPIError:
         error = create_autospec(JSONAPIException, spec_set=True, instance=True)
         error.status_code = 401
         return error
+
+
+class TestAPIForbidden:
+    def test_it(self, pyramid_request):
+        response = api_forbidden(HTTPForbidden(), pyramid_request)
+
+        assert pyramid_request.response.status_int == HTTPForbidden.code
+        assert response == {"error": "invalid_token"}

--- a/tests/unit/checkmate/views/ui/api/login_test.py
+++ b/tests/unit/checkmate/views/ui/api/login_test.py
@@ -4,7 +4,7 @@ import pytest
 from h_matchers import Any
 from pyramid.authentication import SessionAuthenticationPolicy
 
-from checkmate.authentication import GoogleAuthenticationPolicy
+from checkmate.auth import GoogleAuthenticationPolicy
 from checkmate.exceptions import UserNotAuthenticated
 from checkmate.views.ui.api.login import login, login_callback, logout
 


### PR DESCRIPTION
And a forbidden view for the API.

This means that API views can use `permission="foo"` in the `@view_config` and if the request doesn't have the necessary permission the view won't be called and Pyramid will 403 the request instead.

It's no longer necessary to add an "unauthorized" version of each API view to set the error response's status code.

A Pyramid forbidden view is added to change API 403 responses into JSON. The difference between this forbidden view and the `check_url_unauthorized()` view that we had before is that it applies to all API routes, not just to the `"check_url"` route. Also it's the right way to do this in Pyramid.