### PR TITLE
Ignore reasons param on /api/check endpoint

### DIFF
--- a/checkmate/models/reason.py
+++ b/checkmate/models/reason.py
@@ -34,8 +34,12 @@ class Severity(OrderedEnum):
     MANDATORY = "mandatory"
 
 
-class Reason(Enum):
-    """List of reasons a URL can be blocked."""
+class Reason(OrderedEnum):
+    """List of reasons a URL can be blocked.
+
+    The order of definition here is used (based on OrderedEnum) to sort
+    Detections when many are found.
+    """
 
     MALICIOUS = "malicious"  # Actively hostile content of some kind
     PUBLISHER_BLOCKED = "publisher-blocked"  # Content owner has asked us to block

--- a/checkmate/services/url_checker.py
+++ b/checkmate/services/url_checker.py
@@ -37,8 +37,8 @@ class URLCheckerService:
             url_hashes, allow_all, fail_fast, ignore_reasons or []
         )
 
-        # Sort the detections by worst first
-        return reversed(sorted(detections, key=attrgetter("severity")))
+        # Sort the detections by worst first (based on Reason order)
+        return sorted(detections, key=attrgetter("reason"))
 
     def _get_detections(self, url_hashes, allow_all, fail_fast, ignore_reasons):
         detections = []

--- a/checkmate/views/api/check_url.py
+++ b/checkmate/views/api/check_url.py
@@ -48,11 +48,8 @@ def check_url(request):
 
     # Get unique reasons from the detections sorted by severity (decreasing)
     reasons = list(
-        reversed(
-            sorted(
-                set(detection.reason for detection in detections),
-                key=lambda reason: reason.severity,
-            )
+        sorted(
+            set(detection.reason for detection in detections),
         )
     )
 

--- a/tests/unit/checkmate/models/db/custom_rule_test.py
+++ b/tests/unit/checkmate/models/db/custom_rule_test.py
@@ -9,6 +9,8 @@ class TestCustomRule:
     def test_reasons(self):
         reasons = [Reason.HIGH_IO, Reason.MEDIA_IMAGE]
 
-        rule = factories.CustomRule(tags=[reason.value for reason in reasons])
+        rule = factories.CustomRule(
+            tags=[reason.value for reason in reasons]  # pylint: disable=no-member
+        )
 
         assert rule.reasons == reasons

--- a/tests/unit/checkmate/models/reason_test.py
+++ b/tests/unit/checkmate/models/reason_test.py
@@ -66,7 +66,7 @@ class TestReason:
         assert reason.severity == severity
 
     def test_serialise(self):
-        assert Reason.MALICIOUS.serialise() == {
+        assert Reason.MALICIOUS.serialise() == {  # pylint: disable=no-member
             "type": "reason",
             "id": "malicious",
             "attributes": {

--- a/tests/unit/checkmate/services/url_checker_test.py
+++ b/tests/unit/checkmate/services/url_checker_test.py
@@ -47,8 +47,8 @@ class TestURLCheckerService:
         results = checker.check_url("http://example.com", fail_fast=True)
 
         assert list(results) == [
-            Detection(Reason.NOT_ALLOWED, Source.ALLOW_LIST),
             Detection(Reason.HIGH_IO, Source.BLOCK_LIST),
+            Detection(Reason.NOT_ALLOWED, Source.ALLOW_LIST),
             Detection(Reason.OTHER, Source.URL_HAUS),
         ]
 

--- a/tests/unit/checkmate/views/api/check_url_test.py
+++ b/tests/unit/checkmate/views/api/check_url_test.py
@@ -41,6 +41,7 @@ class TestURLCheck:
 
         assert request.response.status_code == 200
         assert result == {
+            # pylint: disable=no-member
             "data": [
                 Reason.MALICIOUS.serialise(),
                 Reason.MEDIA_IMAGE.serialise(),
@@ -58,7 +59,7 @@ class TestURLCheck:
             _host=pyramid_settings["public_host"],
             _query={
                 "url": bad_url,
-                "reason": Reason.MALICIOUS.value,
+                "reason": Reason.MALICIOUS.value,  # pylint: disable=no-member
                 "blocked_for": BlockedFor.GENERAL.value,
             },
         )
@@ -73,7 +74,11 @@ class TestURLCheck:
             {
                 "url": bad_url,
                 "ignore_reasons": ",".join(
-                    [Reason.MALICIOUS.value, Reason.MEDIA_IMAGE.value]
+                    # pylint: disable=no-member
+                    [
+                        Reason.MALICIOUS.value,
+                        Reason.MEDIA_IMAGE.value,
+                    ]
                 ),
             },
         )


### PR DESCRIPTION
Added ignore_reason from API level to service for https://github.com/hypothesis/checkmate/issues/208

Quickly test with:

base check, no reasons ignored

```
curl http://localhost:9099/api/check\?url\=http://www.google.com -u dev_api_key:
{"data": [{"type": "reason", "id": "not-explicitly-allowed", "attributes": {"severity": "advisory"}}], "meta": {"maxSeverity": "advisory"}, "links": {"html": "http://localhost:9099/ui/block?url=http%3A%2F%2Fwww.google.com&reason=not-explicitly-allowed&blocked_for=general&v=1&sec=c7b4e4749159c84cde6de181333fb77da0244f534fd88cccfbd2b1fd0e4a2c1f"}}%
```

reason ignored:

```
curl -I http://localhost:9099/api/check\?url\=http://www.google.com\&ignore_reasons\=not-explicitly-allowed -u dev_api_key:                                                                                      
HTTP/1.1 204 No Content
Server: gunicorn/20.0.4
Date: Wed, 03 Mar 2021 15:34:25 GMT
Connection: close
```

unknown reason ignored, 400 response

```
curl -I http://localhost:9099/api/check\?url\=http://www.google.com\&ignore_reasons\=wat -u dev_api_key:                                                                                                         
HTTP/1.1 400 Bad Request
Server: gunicorn/20.0.4
Date: Wed, 03 Mar 2021 15:34:34 GMT
Connection: close
Content-Type: application/json
Content-Length: 147
```
