### PR TITLE
Point users to the new form to capture information rather than an email

### DIFF
--- a/checkmate/templates/blocked_page.html.jinja2
+++ b/checkmate/templates/blocked_page.html.jinja2
@@ -7,7 +7,7 @@
 {% macro how_to_access(request_access=False) %}
     <h2>To annotate this page</h2>
 
-    <h3>Use our browser extension:</h3>
+    <p>Use our browser extension:</p>
 
     <ol>
         <li>
@@ -23,24 +23,10 @@
     </ol>
 
     {% if request_access %}
-        <h3>Or get in contact:</h3>
-
-        {% set email_subject %}Please allow access to '{{ domain_to_annotate | e }}'{% endset %}
-        {% set email_body -%}
-I'd like to access this page with {{annotated_with}}:
-
-* {{ blocked_url | e }}
-
-I'd like to be able to access this site because ...
-
-<Please give the reasons you'd like to access the site here>
-
-Thanks!
-        {%- endset %}
         <p>
-            <a href="mailto:via@hypothes.is?subject={{ email_subject | urlencode }}&body={{ email_body | urlencode }}" target="_blank"
-            >Email us</a>
-            to let us know you'd like to annotate the page with {{annotated_with}}.
+            Or <a href="https://web.hypothes.is/via-request/?subject={{ blocked_url | urlencode }}">
+                let us know you'd like to annotate the page with {{ annotated_with }}.
+            </a>
         </p>
     {% endif %}
 

--- a/checkmate/views/ui/present_block.py
+++ b/checkmate/views/ui/present_block.py
@@ -1,6 +1,4 @@
 """User feedback for blocked pages."""
-from urllib.parse import urlparse
-
 from pyramid.exceptions import HTTPForbidden
 from pyramid.view import view_config
 
@@ -29,7 +27,6 @@ def present_block(_context, request):
 
     template_args = {
         "blocked_url": url_to_annotate,
-        "domain_to_annotate": urlparse(url_to_annotate).netloc,
         "reason": request.GET["reason"],
     }
 

--- a/tests/unit/checkmate/views/ui/present_block_test.py
+++ b/tests/unit/checkmate/views/ui/present_block_test.py
@@ -13,7 +13,6 @@ class TestPresentBlock:
 
         assert result == {
             "blocked_url": params["url"],
-            "domain_to_annotate": "bad.example.com",  # From "url"
             "reason": params["reason"],
             # Default values:
             "display_how_to_access": True,
@@ -27,7 +26,6 @@ class TestPresentBlock:
 
         assert result == {
             "blocked_url": params["url"],
-            "domain_to_annotate": "bad.example.com",  # From "url"
             "reason": params["reason"],
             "display_how_to_access": False,
             "annotated_with": "Hypothesis",


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/207

This leverages the existing form, and means support get all of their requests through the same medium. This also means support can control the content of the form directly.

## Testing notes

 * Run `make services dev`
 * Visit: http://localhost:9099/ui/block?url=http%3A%2F%2Fanvils.co.uk%2Fwabble%2Fflabble&reason=not-explicitly-allowed&blocked_for=general&v=1&sec=519de0f9575da220ae03243fdbad9faf7423dce5c556c101f16316e8336da487
 * Click on "Or let us know you'd like to annotate the page with Via."
 * This should take you to this form: https://web.hypothes.is/via-request/
 * The URL should be filled out
