### PR TITLE
A very rough script demonstrating talking to Google Web risk

### DIFF
--- a/bin/google_web_risk_demo.py
+++ b/bin/google_web_risk_demo.py
@@ -1,0 +1,88 @@
+import json
+from contextlib import contextmanager
+from datetime import datetime
+
+from google.api_core.exceptions import ClientError, PermissionDenied
+# pip install google-cloud-webrisk
+from google.cloud.webrisk_v1.services.web_risk_service import WebRiskServiceClient
+from google.cloud.webrisk_v1.types.webrisk import SearchUrisRequest, ThreatType
+from google.oauth2 import service_account
+
+
+class WebRiskAPI:
+    THREAT_TYPES = [
+        ThreatType.MALWARE,
+        ThreatType.SOCIAL_ENGINEERING,
+        # ThreatType.UNWANTED_SOFTWARE
+    ]
+
+    def __init__(self, service_account_info):
+        self._credentials = service_account.Credentials.from_service_account_info(
+            service_account_info, scopes=[]
+        )
+
+        self._service = WebRiskServiceClient(credentials=self._credentials)
+
+    def check_url(self, url):
+        # https://googleapis.dev/python/webrisk/latest/webrisk_v1/services.html
+
+        # This isn't really documented from what I can see, but this appears
+        # to be how these object work?
+        request = SearchUrisRequest(uri=url, threat_types=self.THREAT_TYPES)
+
+        # It looks in the docs like you can pass the above arguments straight
+        # to search_uris(), but it seems to fall over it's own validation if
+        # you do that, and complains the passed enum is not an enum
+        try:
+            response = self._service.search_uris(request=request)
+
+        except PermissionDenied as err:
+            print("Oh no, permission denied!", err)
+            raise
+        except ClientError as err:
+            print("On no!", err)
+            raise
+
+        return response.threat.threat_types, response.threat.expire_time
+
+
+@contextmanager
+def timeit():
+    start = datetime.utcnow()
+
+    yield
+
+    diff = datetime.utcnow() - start
+    millis = diff.seconds * 1000 + (diff.microseconds / 1000)
+    print(f"{millis}ms")
+
+
+if __name__ == "__main__":
+    with open("Checkmate-b0fd5a96e470.json") as handle:
+        credentials = json.load(handle)
+
+    url = "http://example.com"
+    url = "http://via3.hypothes.is"
+
+    malicious = [
+        # "sdrjk6ydtckjmndtntre5.web.app",
+        # "ydf774766fygrbehf.web.app",
+        # "t6gr3efetf6tg4y.web.app",
+        "canadacigarsupplies.com",
+        "medyanef.com",
+        # "webmail.belgran.by",
+        # "executivewrite.com",
+        # "nmztd.ru",
+        # "cp.regruhosting.ru",
+        # "manikmeyah.net"
+    ]
+
+    with timeit():
+        web_risk_api = WebRiskAPI(credentials)
+
+    for url in malicious:
+        print(f"CHECKING {url}")
+
+        with timeit():
+            wat = web_risk_api.check_url(url)
+            print("WAT", wat, type(wat))


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/214

This is the per call version, which is much easier to implement, and doesn't require a DB. But we will get charged for every call once we go over our alotted 100,000 per month.

## Testing notes

This requires Google credentials, which I'll provide separately.

* `.tox/dev/bin/pip install google-cloud-webrisk`
* `.tox/dev/bin/python bin/google_web_risk_demo.py`

## Napkin maths

This seems to work, but it's probably time for some napkin maths.

When I ran this it took roughly 250ms to check the first URL, and 40ms per URL after that. I assume this was a small auth bump.

This would be a rate of 1500 / minute. We have 125,000 URLs to check, so assuming everything ran very smoothly this would take 5000 seconds / 83min / 1h23 to check, which isn't too bad. 

However there are quota limits on Web Risk. The limit is 6000 / minute, so we should be inside that on a single, or even a triple threaded solution, which could check the list quite quickly (27 min). However we have seen "secret" quotas over which you just get blocked for a while.

We've seen this as low as 100 / 100 seconds, or basically 1 / second, for Google Drive. If that's the case it would take about 35 hours. Which sucks.

Either way, only the first 100,000 requests are free (and I'll use a bunch during development), so we probably want to ensure that whatever we do here as decent stop / resume type functionality so we don't fail and start over if anything bad happens.