### PR TITLE
Fix urlencoded characters on the URL scheme

### DIFF
--- a/checkmate/url/canonicalize.py
+++ b/checkmate/url/canonicalize.py
@@ -163,7 +163,7 @@ class CanonicalURL:
         """Try and spot hostnames that are really encoded IP addresses."""
         try:
             return str(IPAddress(hostname))
-        except AddrFormatError:
+        except (AddrFormatError, ValueError):
             return None
 
     @classmethod

--- a/tests/unit/checkmate/url/canonicalise_test.py
+++ b/tests/unit/checkmate/url/canonicalise_test.py
@@ -88,6 +88,11 @@ class TestCanonicalURL:
                 "https://www.tumblr.com/search/‘question?’/post_page/2",
                 "https://www.tumblr.com/search/%2018question?%2019/post_page/2",
             ),
+            # Chrome will fail with this one, we should not raise an unexpected exception
+            (
+                "https%3A%2F%2Fwww.google.com",
+                "http://https://www.google.com/",
+            ),
         ),
     )
     def test_canonicalise(self, url, canonical_url):


### PR DESCRIPTION
URLs like https%3A%2F%2Fwww.google.com were failing to get canonalized
resulting on a IPAddress() does not support netmasks exception.

This correctly handles the error and produces an incorrect URL as
urlencoding should not be used on that part of the URL (and browsers
don't allow them either).

Fixes https://sentry.io/organizations/hypothesis/issues/2268126700/?referrer=slack