### PR TITLE
Blocked pages return 400 status code

### DIFF
--- a/checkmate/views/ui/present_block.py
+++ b/checkmate/views/ui/present_block.py
@@ -1,5 +1,5 @@
 """User feedback for blocked pages."""
-from pyramid.exceptions import HTTPForbidden
+from pyramid.httpexceptions import HTTPUnauthorized
 from pyramid.view import view_config
 
 from checkmate.models import BlockedFor
@@ -19,7 +19,7 @@ def present_block(_context, request):
     """Render an HTML version of a blocked URL with explanation."""
 
     if not request.find_service(SecureLinkService).is_secure(request):
-        raise HTTPForbidden()
+        raise HTTPUnauthorized()
 
     # At this point we know the contents of the args came from us, so we'll
     # assume that they are correct.
@@ -33,5 +33,5 @@ def present_block(_context, request):
     # Tweak the pages based on where they are going to be displayed
     blocked_for = BlockedFor.parse(request.GET.get("blocked_for"))
 
-    request.response.status = 400
+    request.response.status = 403
     return {**template_args, **blocked_for.extra_args}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
+import functools
 import os
 
 import httpretty
 import pytest
+from pyramid.testing import DummyRequest, testConfig
 
 from checkmate.db import create_engine
 
@@ -47,3 +49,14 @@ def httpretty_():
 
     httpretty.disable()
     httpretty.reset()
+
+
+@pytest.fixture
+def route_url():
+    request = DummyRequest(
+        environ={"SERVER_NAME": "localhost", "wsgi.url_scheme": "https"}
+    )
+
+    with testConfig(request=request) as config:
+        config.include("checkmate.routes")
+        yield functools.partial(request.route_url, _scheme="https")

--- a/tests/functional/checkmate/views/ui/present_block_test.py
+++ b/tests/functional/checkmate/views/ui/present_block_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from checkmate.services import SecureLinkService, SignatureService
+
+
+class TestAPIAuth:
+    def test_if_the_link_is_not_signed_it_401s(self, app, route_url):
+        # `url` will be an unsigned link (it doesn't come from
+        # SecureLinkService).
+        url = route_url("present_block", _query={"url": "example.com"})
+
+        app.get(url, status=401)
+
+    def test_if_the_link_is_signed_it_renders_the_block_page(
+        self, app, secure_link_service
+    ):
+        url = secure_link_service.route_url(
+            "present_block",
+            _query={"url": "example.com", "reason": "not-explicitly-allowed"},
+        )
+
+        res = app.get(url, status=403)
+
+    @pytest.fixture
+    def secure_link_service(self, pyramid_settings, route_url):
+        signature_service = SignatureService(pyramid_settings["secret"])
+        secure_link_service = SecureLinkService(signature_service, route_url)
+        return secure_link_service

--- a/tests/unit/checkmate/views/ui/present_block_test.py
+++ b/tests/unit/checkmate/views/ui/present_block_test.py
@@ -1,7 +1,7 @@
 from unittest.mock import sentinel
 
 import pytest
-from pyramid.httpexceptions import HTTPForbidden
+from pyramid.httpexceptions import HTTPUnauthorized
 
 from checkmate.views.ui.present_block import present_block
 
@@ -35,7 +35,7 @@ class TestPresentBlock:
         secure_link_service.is_secure.return_value = False
         request = make_request(params=params)
 
-        with pytest.raises(HTTPForbidden):
+        with pytest.raises(HTTPUnauthorized):
             present_block(sentinel.context, request)
 
         secure_link_service.is_secure.assert_called_once_with(request)


### PR DESCRIPTION
Testing locally, something like:

``` curl -s http://localhost:9099/api/check\?url\=http://www.google.com -u dev_api_key: | jq ".links.html" | xargs curl -I```

I thought adding a small functional test around this might be useful but didn't find not painful way to sign the /ui/block request from a functional test.