### PR TITLE
Secure the allow list end-point

### DIFF
--- a/checkmate/views/ui/api/add_to_allow_list.py
+++ b/checkmate/views/ui/api/add_to_allow_list.py
@@ -3,6 +3,7 @@ from marshmallow_jsonapi import Schema, fields
 from pyramid.view import view_config
 from webargs.pyramidparser import use_kwargs
 
+from checkmate.models import Principals
 from checkmate.services import RuleService
 from checkmate.url import CanonicalURL, Domain
 
@@ -40,7 +41,12 @@ class AllowRuleSchema(Schema):
 _ALLOW_RULE_SCHEMA = AllowRuleSchema()
 
 
-@view_config(route_name="add_to_allow_list", request_method="POST", renderer="json")
+@view_config(
+    route_name="add_to_allow_list",
+    request_method="POST",
+    renderer="json",
+    effective_principals=[Principals.STAFF],
+)
 @use_kwargs(_ALLOW_RULE_SCHEMA)
 def add_to_allow_list(request, url):
     """Add a rule matching `url` to the allow list."""


### PR DESCRIPTION
This didn't have any authentication on it, but it really should. The reason this appeared to have auth was that if you send incorrect or expired auth you get kicked out. I didn't try sending none.

This is a decent example of why I'm not over the moon about so much of the config and construction of the app being opaque to unit tests as we don't have a nice way of quickly checking this stuff.