### PR TITLE
Add httpretty to functests

### DIFF
--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -1,3 +1,4 @@
+httpretty
 pytest
 webtest
 h-matchers

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -72,6 +72,8 @@ h-matchers==1.2.10
     # via -r requirements/functests.in
 h-pyramid-sentry==1.2.1
     # via -r requirements/requirements.txt
+httpretty==1.0.5
+    # via -r requirements/functests.in
 hupper==1.10.2
     # via
     #   -r requirements/requirements.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 
+import httpretty
 import pytest
 
 from checkmate.db import create_engine
@@ -30,3 +31,19 @@ def pyramid_settings():
         "public_scheme": "http",
         "public_port": "9099",
     }
+
+
+@pytest.fixture(autouse=True)
+def httpretty_():
+    """Monkey-patch Python's socket core module to mock all HTTP responses.
+
+    We never want real HTTP requests to be sent by the tests so replace them
+    all with mock responses. This handles requests sent using the standard
+    urllib2 library and the third-party httplib2 and requests libraries.
+    """
+    httpretty.enable(allow_net_connect=False)
+
+    yield
+
+    httpretty.disable()
+    httpretty.reset()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,7 +4,6 @@ import functools
 from unittest.mock import MagicMock
 from urllib.parse import urlencode
 
-import httpretty
 import sqlalchemy
 from pyramid import testing
 from pyramid.request import Request, apply_request_extensions
@@ -102,19 +101,3 @@ def db_session(db_engine):
         session.close()  # pylint:disable=no-member
         trans.rollback()
         conn.close()
-
-
-@pytest.fixture(autouse=True)
-def httpretty_():
-    """Monkey-patch Python's socket core module to mock all HTTP responses.
-
-    We never want real HTTP requests to be sent by the tests so replace them
-    all with mock responses. This handles requests sent using the standard
-    urllib2 library and the third-party httplib2 and requests libraries.
-    """
-    httpretty.enable(allow_net_connect=False)
-
-    yield
-
-    httpretty.disable()
-    httpretty.reset()


### PR DESCRIPTION
We don't want our functional tests to be talking to the real network (e.g. Google's OAuth 2 server), for the same reason that we don't want our unit tests to.