### PR TITLE
Use PyJWT not `jwt`

### DIFF
--- a/checkmate/services/google_auth.py
+++ b/checkmate/services/google_auth.py
@@ -1,9 +1,9 @@
 import os
 from urllib.parse import parse_qsl, urlparse
 
+import jwt
 from google_auth_oauthlib.flow import Flow
-from jwt import JWT
-from jwt.exceptions import JWTDecodeError
+from jwt import InvalidTokenError
 from oauthlib.oauth2.rfc6749.errors import InvalidClientError, InvalidGrantError
 
 from checkmate.exceptions import BadOAuth2Config, UserNotAuthenticated
@@ -143,9 +143,9 @@ class GoogleAuthService:
         try:
             # Don't bother checking this came from Google, we know the request
             # came from Google by virtue of the state/nonce.
-            return JWT().decode(id_token, do_verify=False)
+            return jwt.decode(id_token, options=dict(verify_signature=False))
 
-        except JWTDecodeError as err:
+        except InvalidTokenError as err:
             # This could actually be because we have the wrong key... but we
             # can't tell the difference, and this is more likely
             raise UserNotAuthenticated(

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,6 @@ certifi==2020.11.8
     #   sentry-sdk
 cffi==1.14.4
     # via
-    #   -r requirements/requirements.txt
     #   bcrypt
     #   cryptography
     #   pynacl
@@ -63,10 +62,7 @@ click==7.1.2
     #   click-plugins
     #   click-repl
 cryptography==3.2.1
-    # via
-    #   -r requirements/requirements.txt
-    #   jwt
-    #   paramiko
+    # via paramiko
 decorator==4.4.2
     # via
     #   ipython
@@ -129,8 +125,6 @@ jinja2==2.11.2
     #   pyramid-jinja2
 jsonschema==3.2.0
     # via docker-compose
-jwt==1.2.0
-    # via -r requirements/requirements.txt
 kombu==5.0.2
     # via
     #   -r requirements/requirements.txt
@@ -200,11 +194,11 @@ pyasn1==0.4.8
     #   pyasn1-modules
     #   rsa
 pycparser==2.20
-    # via
-    #   -r requirements/requirements.txt
-    #   cffi
+    # via cffi
 pygments==2.7.2
     # via ipython
+pyjwt==2.0.1
+    # via -r requirements/requirements.txt
 pynacl==1.4.0
     # via paramiko
 pyramid-exclog==1.0

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -29,10 +29,6 @@ certifi==2020.11.8
     #   -r requirements/requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.14.4
-    # via
-    #   -r requirements/requirements.txt
-    #   cryptography
 chardet==3.0.4
     # via
     #   -r requirements/requirements.txt
@@ -56,10 +52,6 @@ click==7.1.2
     #   click-didyoumean
     #   click-plugins
     #   click-repl
-cryptography==3.2.1
-    # via
-    #   -r requirements/requirements.txt
-    #   jwt
 google-auth-oauthlib==0.4.3
     # via -r requirements/requirements.txt
 google-auth==1.24.0
@@ -96,8 +88,6 @@ jinja2==2.11.2
     # via
     #   -r requirements/requirements.txt
     #   pyramid-jinja2
-jwt==1.2.0
-    # via -r requirements/requirements.txt
 kombu==5.0.2
     # via
     #   -r requirements/requirements.txt
@@ -161,10 +151,8 @@ pyasn1==0.4.8
     #   -r requirements/requirements.txt
     #   pyasn1-modules
     #   rsa
-pycparser==2.20
-    # via
-    #   -r requirements/requirements.txt
-    #   cffi
+pyjwt==2.0.1
+    # via -r requirements/requirements.txt
 pyparsing==2.4.7
     # via packaging
 pyramid-exclog==1.0
@@ -220,7 +208,6 @@ six==1.15.0
     # via
     #   -r requirements/requirements.txt
     #   click-repl
-    #   cryptography
     #   google-auth
     #   python-dateutil
     #   webtest

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -43,11 +43,6 @@ certifi==2020.11.8
     #   -r requirements/tests.txt
     #   requests
     #   sentry-sdk
-cffi==1.14.4
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   cryptography
 chardet==3.0.4
     # via
     #   -r requirements/requirements.txt
@@ -78,11 +73,6 @@ click==7.1.2
     #   click-repl
 coverage==5.5
     # via -r requirements/tests.txt
-cryptography==3.2.1
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   jwt
 factory-boy==3.2.0
     # via -r requirements/tests.txt
 faker==4.17.1
@@ -145,10 +135,6 @@ jinja2==2.11.2
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   pyramid-jinja2
-jwt==1.2.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
 kombu==5.0.2
     # via
     #   -r requirements/requirements.txt
@@ -241,13 +227,12 @@ pyasn1==0.4.8
     #   -r requirements/tests.txt
     #   pyasn1-modules
     #   rsa
-pycparser==2.20
+pydocstyle==6.0.0
+    # via -r requirements/lint.in
+pyjwt==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   cffi
-pydocstyle==6.0.0
-    # via -r requirements/lint.in
 pylint==2.7.2
     # via -r requirements/lint.in
 pyparsing==2.4.7
@@ -331,7 +316,6 @@ six==1.15.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   click-repl
-    #   cryptography
     #   google-auth
     #   packaging
     #   python-dateutil

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -2,7 +2,7 @@ alembic
 celery
 google-auth-oauthlib
 gunicorn
-jwt
+PyJWT
 marshmallow-jsonapi
 netaddr
 newrelic

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,8 +18,6 @@ certifi==2020.11.8
     # via
     #   requests
     #   sentry-sdk
-cffi==1.14.4
-    # via cryptography
 chardet==3.0.4
     # via requests
 click-didyoumean==0.0.3
@@ -34,8 +32,6 @@ click==7.1.2
     #   click-didyoumean
     #   click-plugins
     #   click-repl
-cryptography==3.2.1
-    # via jwt
 google-auth-oauthlib==0.4.3
     # via -r requirements/requirements.in
 google-auth==1.24.0
@@ -54,8 +50,6 @@ importlib-resources==3.3.0
     # via netaddr
 jinja2==2.11.2
     # via pyramid-jinja2
-jwt==1.2.0
-    # via -r requirements/requirements.in
 kombu==5.0.2
     # via celery
 mako==1.1.3
@@ -95,8 +89,8 @@ pyasn1==0.4.8
     # via
     #   pyasn1-modules
     #   rsa
-pycparser==2.20
-    # via cffi
+pyjwt==2.0.1
+    # via -r requirements/requirements.in
 pyramid-exclog==1.0
     # via -r requirements/requirements.in
 pyramid-jinja2==2.8
@@ -135,7 +129,6 @@ sentry-sdk==0.19.4
 six==1.15.0
     # via
     #   click-repl
-    #   cryptography
     #   google-auth
     #   python-dateutil
 sqlalchemy==1.3.20

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -29,10 +29,6 @@ certifi==2020.11.8
     #   -r requirements/requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.14.4
-    # via
-    #   -r requirements/requirements.txt
-    #   cryptography
 chardet==3.0.4
     # via
     #   -r requirements/requirements.txt
@@ -58,10 +54,6 @@ click==7.1.2
     #   click-repl
 coverage==5.5
     # via -r requirements/tests.in
-cryptography==3.2.1
-    # via
-    #   -r requirements/requirements.txt
-    #   jwt
 factory-boy==3.2.0
     # via -r requirements/tests.in
 faker==4.17.1
@@ -104,8 +96,6 @@ jinja2==2.11.2
     # via
     #   -r requirements/requirements.txt
     #   pyramid-jinja2
-jwt==1.2.0
-    # via -r requirements/requirements.txt
 kombu==5.0.2
     # via
     #   -r requirements/requirements.txt
@@ -169,10 +159,8 @@ pyasn1==0.4.8
     #   -r requirements/requirements.txt
     #   pyasn1-modules
     #   rsa
-pycparser==2.20
-    # via
-    #   -r requirements/requirements.txt
-    #   cffi
+pyjwt==2.0.1
+    # via -r requirements/requirements.txt
 pyparsing==2.4.7
     # via packaging
 pyramid-exclog==1.0
@@ -229,7 +217,6 @@ six==1.15.0
     # via
     #   -r requirements/requirements.txt
     #   click-repl
-    #   cryptography
     #   google-auth
     #   packaging
     #   python-dateutil


### PR DESCRIPTION
PyJWT (https://pypi.org/project/PyJWT/) not `jwt` (https://pypi.org/project/jwt/) is the JWT library that we use:

https://github.com/hypothesis/lms/blob/7c86845b49c34673af9aa5e877c32ee4c6d442d0/requirements/requirements.in#L17
https://github.com/hypothesis/h/blob/37405e511f47dc1e67f6496bf69b68700063deac/requirements/requirements.in#L8

PyJWT is a nicer library with better docs and is much more popular (3700 GitHub stars vs 81, used by 104,000 projects vs 2800, 91 contributors vs 10).