### PR TITLE
Added a secret to the cache key on github actions.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,8 +29,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .tox
-        key: ${{ runner.os }}-tox-${{ hashFiles('tox.ini', 'requirements*', 'setup.py', 'setup.cfg') }}
+        key: ${{ runner.os }}-tox-${{ secrets.CACHE_VERSION }}-${{ hashFiles('tox.ini', 'requirements*', 'setup.py', 'setup.cfg') }}
         restore-keys: |
-          ${{ runner.os }}-tox-
+          ${{ runner.os }}-tox-${{ secrets.CACHE_VERSION }}-
     - name: Run tox
       run: tox --parallel auto -e lint,checkformatting,tests,functests


### PR DESCRIPTION
This allows to change the key in case the cache gets corrupted without
needing to make extra changes to the workflow file.

Run the job twice, the second run:

```
Post job cleanup.
Cache hit occurred on the primary key Linux-tox-***-27599f5fd33f2c4b8873437d4e2516da4fdf99b39813cea35a71f7428f364e80, not saving cache.
```