### PR TITLE
Revert "Upgrade to SQLAlchemy 1.4.3"

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -87,10 +87,6 @@ google-auth==1.24.0
     # via
     #   -r requirements/requirements.txt
     #   google-auth-oauthlib
-greenlet==1.0.0
-    # via
-    #   -r requirements/requirements.txt
-    #   sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.1
@@ -108,7 +104,6 @@ importlib-metadata==3.1.0
     #   -r requirements/requirements.txt
     #   jsonschema
     #   kombu
-    #   sqlalchemy
 importlib-resources==3.3.0
     # via
     #   -r requirements/requirements.txt
@@ -279,7 +274,7 @@ six==1.15.0
     #   python-dateutil
     #   traitlets
     #   websocket-client
-sqlalchemy==1.4.3
+sqlalchemy==1.3.20
     # via
     #   -r requirements/requirements.txt
     #   alembic

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -58,10 +58,6 @@ google-auth==1.24.0
     # via
     #   -r requirements/requirements.txt
     #   google-auth-oauthlib
-greenlet==1.0.0
-    # via
-    #   -r requirements/requirements.txt
-    #   sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
 h-matchers==1.2.10
@@ -84,7 +80,6 @@ importlib-metadata==3.1.0
     #   kombu
     #   pluggy
     #   pytest
-    #   sqlalchemy
 importlib-resources==3.3.0
     # via
     #   -r requirements/requirements.txt
@@ -220,7 +215,7 @@ six==1.15.0
     #   webtest
 soupsieve==2.1
     # via beautifulsoup4
-sqlalchemy==1.4.3
+sqlalchemy==1.3.20
     # via
     #   -r requirements/requirements.txt
     #   alembic

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -88,11 +88,6 @@ google-auth==1.24.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   google-auth-oauthlib
-greenlet==1.0.0
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
-    #   sqlalchemy
 gunicorn==20.1.0
     # via
     #   -r requirements/requirements.txt
@@ -124,7 +119,6 @@ importlib-metadata==3.1.0
     #   kombu
     #   pluggy
     #   pytest
-    #   sqlalchemy
 importlib-resources==3.3.0
     # via
     #   -r requirements/requirements.txt
@@ -332,7 +326,7 @@ soupsieve==2.0.1
     # via
     #   -r requirements/tests.txt
     #   beautifulsoup4
-sqlalchemy==1.4.3
+sqlalchemy==1.3.20
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -36,8 +36,6 @@ google-auth-oauthlib==0.4.4
     # via -r requirements/requirements.in
 google-auth==1.24.0
     # via google-auth-oauthlib
-greenlet==1.0.0
-    # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.1
@@ -47,9 +45,7 @@ hupper==1.10.2
 idna==2.10
     # via requests
 importlib-metadata==3.1.0
-    # via
-    #   kombu
-    #   sqlalchemy
+    # via kombu
 importlib-resources==3.3.0
     # via netaddr
 jinja2==2.11.2
@@ -135,7 +131,7 @@ six==1.15.0
     #   click-repl
     #   google-auth
     #   python-dateutil
-sqlalchemy==1.4.3
+sqlalchemy==1.3.20
     # via
     #   -r requirements/requirements.in
     #   alembic

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -64,10 +64,6 @@ google-auth==1.24.0
     # via
     #   -r requirements/requirements.txt
     #   google-auth-oauthlib
-greenlet==1.0.0
-    # via
-    #   -r requirements/requirements.txt
-    #   sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
 h-matchers==1.2.10
@@ -90,7 +86,6 @@ importlib-metadata==3.1.0
     #   kombu
     #   pluggy
     #   pytest
-    #   sqlalchemy
 importlib-resources==3.3.0
     # via
     #   -r requirements/requirements.txt
@@ -228,7 +223,7 @@ six==1.15.0
     #   webtest
 soupsieve==2.0.1
     # via beautifulsoup4
-sqlalchemy==1.4.3
+sqlalchemy==1.3.20
     # via
     #   -r requirements/requirements.txt
     #   alembic


### PR DESCRIPTION
Reverts hypothesis/checkmate#268. SQLAlchemy 1.4.3 didn't work on QA, see https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1617103413018000