### PR TITLE
Let hdev inject pip-tools dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ setenv =
 
 passenv =
     HOME
+    EXTRA_DEPS
     dev: CHROME_EXTENSION_ID
     dev: SENTRY_DSN
     dev: NEW_RELIC_LICENSE_KEY
@@ -56,7 +57,7 @@ deps =
     updatepdfjs: -r requirements/updatepdfjs.txt
     build: -r requirements/build.txt
     dockercompose: -r requirements/dockercompose.txt
-    pip-tools<5.0.0
+    {env:EXTRA_DEPS:}
 whitelist_externals =
     dev: gunicorn
     dev: newrelic-admin


### PR DESCRIPTION
~~Depends on https://github.com/hypothesis/hdev/pull/7 to be merged first~~

Upgrade hdev
```pip install hdev --upgrade
Requirement already satisfied: hdev in /home/marcos/.pyenv/versions/3.6.9/lib/python3.6/site-packages/hdev-0.1.1-py3.6.egg (0.1.1)
Collecting hdev
  Downloading hdev-0.1.2-py3-none-any.whl (9.0 kB)
Requirement already satisfied: toml in /home/marcos/.pyenv/versions/3.6.9/lib/python3.6/site-packages (from hdev) (0.10.2)
Installing collected packages: hdev
  Attempting uninstall: hdev
    Found existing installation: hdev 0.1.1
    Uninstalling hdev-0.1.1:
      Successfully uninstalled hdev-0.1.1
Successfully installed hdev-0.1.2
```
Then a new file is used to build the enviorment

```
hdev requirements 
dev recreate: /home/marcos/hypo/checkmate/.tox/dev
dev bootstrap: venv-update>=2.1.3
dev installdeps: -e.,-rrequirements/dev.txt,-r/home/marcos/.pyenv/versions/3.6.9/lib/python3.6/site-packages/hdev/requirements/pip-tools.txt
...
```
