### PR TITLE
Use DummyRequest and other pyramid.testing stuff

### DIFF
--- a/tests/unit/checkmate/services/google_auth_test.py
+++ b/tests/unit/checkmate/services/google_auth_test.py
@@ -185,4 +185,4 @@ class TestFactory:
         assert result._signature_service == signature_service
         assert result._client_id == sentinel.google_client_id
         assert result._client_secret == sentinel.google_client_secret
-        assert result._redirect_uri == "http://localhost/ui/api/login_callback"
+        assert result._redirect_uri == "http://example.com/ui/api/login_callback"

--- a/tests/unit/checkmate/views/api/check_url_test.py
+++ b/tests/unit/checkmate/views/api/check_url_test.py
@@ -8,14 +8,12 @@ from checkmate.views.api.check_url import check_url
 @pytest.mark.usefixtures("secure_link_service", "url_checker_service")
 class TestURLCheck:
     @pytest.mark.parametrize("allow_all", ("1", None))
-    def test_a_good_url(self, make_request, allow_all, url_checker_service):
-        params = {"url": "http://happy.example.com"}
+    def test_a_good_url(self, pyramid_request, allow_all, url_checker_service):
+        pyramid_request.params["url"] = "http://happy.example.com"
         if allow_all:
-            params["allow_all"] = allow_all
+            pyramid_request.params["allow_all"] = allow_all
 
-        request = make_request("/api/check", params)
-
-        response = check_url(request)
+        response = check_url(pyramid_request)
 
         assert response.status_code == 204
 
@@ -26,20 +24,22 @@ class TestURLCheck:
         )
 
     def test_a_bad_url(
-        self, make_request, url_checker_service, secure_link_service, pyramid_settings
+        self,
+        pyramid_request,
+        url_checker_service,
+        secure_link_service,
+        pyramid_settings,
     ):
         url_checker_service.check_url.return_value = (
             Detection(Reason.MALICIOUS, Source.URL_HAUS),
             Detection(Reason.MEDIA_IMAGE, Source.BLOCK_LIST),
             Detection(Reason.MEDIA_IMAGE, Source.BLOCK_LIST),
         )
-        bad_url = "http://sad.example.com"
+        pyramid_request.params["url"] = "http://sad.example.com"
 
-        request = make_request("/api/check", {"url": bad_url})
+        result = check_url(pyramid_request)
 
-        result = check_url(request)
-
-        assert request.response.status_code == 200
+        assert pyramid_request.response.status_code == 200
         assert result == {
             # pylint: disable=no-member
             "data": [
@@ -58,57 +58,50 @@ class TestURLCheck:
             _port=pyramid_settings["public_port"],
             _host=pyramid_settings["public_host"],
             _query={
-                "url": bad_url,
+                "url": pyramid_request.params["url"],
                 "reason": Reason.MALICIOUS.value,  # pylint: disable=no-member
                 "blocked_for": BlockedFor.GENERAL.value,
             },
         )
 
-    def test_a_bad_url_ignored_reasons(self, make_request, url_checker_service):
-        bad_url = "http://sad.example.com"
-
-        request = make_request(
-            "/api/check",
+    def test_a_bad_url_ignored_reasons(self, pyramid_request, url_checker_service):
+        pyramid_request.params.update(
             {
-                "url": bad_url,
+                "url": "http://sad.example.com",
                 "ignore_reasons": ",".join(
-                    # pylint: disable=no-member
                     [
-                        Reason.MALICIOUS.value,
-                        Reason.MEDIA_IMAGE.value,
+                        Reason.MALICIOUS.value,  # pylint:disable=no-member
+                        Reason.MEDIA_IMAGE.value,  # pylint:disable=no-member
                     ]
                 ),
-            },
+            }
         )
 
-        check_url(request)
+        check_url(pyramid_request)
 
         url_checker_service.check_url.assert_called_once_with(
-            "http://sad.example.com",
+            pyramid_request.params["url"],
             allow_all=None,
             ignore_reasons=set([Reason.MEDIA_IMAGE, Reason.MALICIOUS]),
         )
 
-    def test_it_returns_an_error_for_no_url(self, make_request):
-        request = make_request("/api/check")
-
+    def test_it_returns_an_error_for_no_url(self, pyramid_request):
         with pytest.raises(BadURLParameter):
-            check_url(request)
+            check_url(pyramid_request)
 
-    def test_it_returns_an_error_for_unknown_ignore_reason(self, make_request):
-        request = make_request(
-            "/api/check", {"url": "example.com", "ignore_reasons": "whatever"}
+    def test_it_returns_an_error_for_unknown_ignore_reason(self, pyramid_request):
+        pyramid_request.params.update(
+            {"url": "example.com", "ignore_reasons": "whatever"}
         )
 
         with pytest.raises(BadURLParameter):
-            check_url(request)
+            check_url(pyramid_request)
 
     def test_it_returns_an_error_for_invalid_url(
-        self, make_request, url_checker_service
+        self, pyramid_request, url_checker_service
     ):
-        request = make_request("/api/check", {"url": "http://example.com]"})
-
+        pyramid_request.params["url"] = "http://example.com]"
         url_checker_service.check_url.side_effect = MalformedURL()
 
         with pytest.raises(BadURLParameter):
-            check_url(request)
+            check_url(pyramid_request)

--- a/tests/unit/checkmate/views/root_test.py
+++ b/tests/unit/checkmate/views/root_test.py
@@ -10,4 +10,4 @@ class TestRoot:
         response = root(sentinel.context, pyramid_request)
 
         assert isinstance(response, HTTPFound)
-        assert response.location == "http://localhost/ui/api/login"
+        assert response.location == "http://example.com/ui/api/login"

--- a/tests/unit/checkmate/views/status_test.py
+++ b/tests/unit/checkmate/views/status_test.py
@@ -4,9 +4,5 @@ from checkmate.views.status import get_status
 
 
 class TestStatusRoute:
-    def test_status_returns_a_response(self, make_request):
-        request = make_request("/status")
-
-        result = get_status(request)
-
-        assert result == Any.dict()
+    def test_status_returns_a_response(self, pyramid_request):
+        assert get_status(pyramid_request) == Any.dict()

--- a/tests/unit/checkmate/views/ui/admin_test.py
+++ b/tests/unit/checkmate/views/ui/admin_test.py
@@ -23,7 +23,7 @@ class TestAdminPagesLoggedOut:
         response = admin_pages_logged_out(sentinel.context, pyramid_request)
 
         assert isinstance(response, HTTPFound)
-        assert response.location == "http://localhost/ui/api/login"
+        assert response.location == "http://example.com/ui/api/login"
 
 
 class TestAdminLoginFailure:

--- a/tests/unit/checkmate/views/ui/api/add_to_allow_list_test.py
+++ b/tests/unit/checkmate/views/ui/api/add_to_allow_list_test.py
@@ -61,7 +61,7 @@ class TestAllowRuleSchema:
             target[path[-1]] = value
 
 
-@pytest.mark.usefixtures("rule_service", "session")
+@pytest.mark.usefixtures("rule_service")
 class TestAddToAllowList:
     def test_it(self, pyramid_request, rule_service):
         pyramid_request.jsonapi = JSONAPIBody(

--- a/tests/unit/checkmate/views/ui/present_block_test.py
+++ b/tests/unit/checkmate/views/ui/present_block_test.py
@@ -8,43 +8,44 @@ from checkmate.views.ui.present_block import present_block
 
 @pytest.mark.usefixtures("secure_link_service")
 class TestPresentBlock:
-    def test_it_passes_through_params(self, make_request, params):
-        result = present_block(sentinel.context, make_request(params=params))
+    def test_it_passes_through_params(self, pyramid_request):
+        result = present_block(sentinel.context, pyramid_request)
 
         assert result == {
-            "blocked_url": params["url"],
-            "reason": params["reason"],
+            "blocked_url": pyramid_request.params["url"],
+            "reason": pyramid_request.params["reason"],
             # Default values:
             "display_how_to_access": True,
             "annotated_with": "Via",
         }
 
-    def test_passes_params_for_lms(self, make_request, params):
-        params = dict(params)
-        params["blocked_for"] = "lms"
-        result = present_block(sentinel.context, make_request(params=params))
+    def test_passes_params_for_lms(self, pyramid_request):
+        pyramid_request.params["blocked_for"] = "lms"
+        result = present_block(sentinel.context, pyramid_request)
 
         assert result == {
-            "blocked_url": params["url"],
-            "reason": params["reason"],
+            "blocked_url": pyramid_request.params["url"],
+            "reason": pyramid_request.params["reason"],
             "display_how_to_access": False,
             "annotated_with": "Hypothesis",
         }
 
-    def test_it_checks_param_signing(self, make_request, secure_link_service, params):
+    def test_it_checks_param_signing(self, pyramid_request, secure_link_service):
         secure_link_service.is_secure.return_value = False
-        request = make_request(params=params)
 
         with pytest.raises(HTTPUnauthorized):
-            present_block(sentinel.context, request)
+            present_block(sentinel.context, pyramid_request)
 
-        secure_link_service.is_secure.assert_called_once_with(request)
+        secure_link_service.is_secure.assert_called_once_with(pyramid_request)
 
     @pytest.fixture
-    def params(self):
-        return {
-            "url": "http://bad.example.com",
-            "reason": "malicious",
-            "v": "1",
-            "sec": "some-long-token",
-        }
+    def pyramid_request(self, pyramid_request):
+        pyramid_request.params.update(
+            {
+                "url": "http://bad.example.com",
+                "reason": "malicious",
+                "v": "1",
+                "sec": "some-long-token",
+            }
+        )
+        return pyramid_request


### PR DESCRIPTION
Replace the `pyramid_request` and `make_request()` fixtures that returned real `Request` objects with a new `pyramid_request` fixture that returns a `DummyRequest`.

Remove the `session` fixture: tests can now access the `DummySession` object as `pyramid_request.session`.

This enables us to use all the standard Pyramid testing stuff like DummyRequest, DummySession, DummyResource, DummySecurityPolicy, DummyTemplateRenderer, testing_add_renderer(), testing_add_subscriber(), testing_resource(), testing_securitypolicy().

This is also consistent with our other apps.

See:

* https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/testing.html
* https://docs.pylonsproject.org/projects/pyramid/en/latest/api/testing.html
* Testing Helper APIs in https://docs.pylonsproject.org/projects/pyramid/en/latest/api/config.html