### PR TITLE
Fix Jenkins by allowing the test DB URL through

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,7 @@ passenv =
     dev: CHECKMATE_BLOCKLIST_URL
     dev: GOOGLE_CLIENT_ID
     dev: GOOGLE_CLIENT_SECRET
+    tests: TEST_DATABASE_URL
 deps =
     dev: -e .
     dev: -r requirements/dev.txt


### PR DESCRIPTION
This didn't show up in testing as it only fails in Jenkins, not GHA. By the looks of it I'd guess any environment variable you set in tox is implicitly included in the pass through settings?