### PR TITLE
Update sentry

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -260,7 +260,7 @@ rsa==4.7
     # via
     #   -r requirements/requirements.txt
     #   google-auth
-sentry-sdk==0.19.4
+sentry-sdk==1.0.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -206,7 +206,7 @@ rsa==4.7
     # via
     #   -r requirements/requirements.txt
     #   google-auth
-sentry-sdk==0.19.4
+sentry-sdk==1.0.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -311,7 +311,7 @@ rsa==4.7
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   google-auth
-sentry-sdk==0.19.4
+sentry-sdk==1.0.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -126,7 +126,7 @@ requests==2.25.1
     #   requests-oauthlib
 rsa==4.7
     # via google-auth
-sentry-sdk==0.19.4
+sentry-sdk==1.0.0
     # via h-pyramid-sentry
 six==1.15.0
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -213,7 +213,7 @@ rsa==4.7
     # via
     #   -r requirements/requirements.txt
     #   google-auth
-sentry-sdk==0.19.4
+sentry-sdk==1.0.0
     # via
     #   -r requirements/requirements.txt
     #   h-pyramid-sentry


### PR DESCRIPTION
`BREAKING CHANGE: Feat: Moved auto_session_tracking experimental flag to a proper option and removed explicitly setting experimental session_mode in favor of auto detecting its value, hence enabling release health by default #994`

We don't seem to be using that here or in h-pyramid-sentry 

But can't tell why we didn't get a dependabot update for this one, only this in the logs:

```  proxy | 2021/04/06 10:10:23 [076] GET https://pypi.org:443/simple/sentry-sdk/
  proxy | 2021/04/06 10:10:23 [076] 200 https://pypi.org:443/simple/sentry-sdk/
```