### PR TITLE
Update development setup and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ installation process:
 
     cd checkmate
 
+### Create the development data and settings
+
 Some functionality involves calls to external services (eg. Google login for the
 admin pages) which requires API keys. To download these keys run:
 


### PR DESCRIPTION
Add a step to the README that I found missing [1] while trying to set up
Checkmate locally:

 - Run `make devdata` to fetch Google API keys

I also added a section related to using Checkmate in a development environment:

 - Document how to authenticate requests using HTTP Basic auth
 - Document how to access the admin pages

I realize that most usage of Checkmate is done via other services using a Python library, but I think it is useful to explain how to execute simple requests directly.

[1] https://hypothes-is.slack.com/archives/C1MA4E9B9/p1618317414401500