### PR TITLE
Change environment names in New Relic config to match used values

### DIFF
--- a/conf/newrelic.ini
+++ b/conf/newrelic.ini
@@ -186,26 +186,14 @@ distributed_tracing.enabled = false
 
 # ---------------------------------------------------------------------------
 
-#
 # The application environments. These are specific settings which
-# override the common environment settings. The settings related to a
-# specific environment will be used when the environment argument to the
-# newrelic.agent.initialize() function has been defined to be either
-# "development", "test", "staging" or "production".
-#
+# override the common environment settings.
 
-[newrelic:development]
+[newrelic:dev]
 monitor_mode = false
 
-[newrelic:test]
-monitor_mode = false
-
-[newrelic:staging]
-app_name = Python Application (Staging)
+[newrelic:qa]
 monitor_mode = true
 
-[newrelic:production]
+[newrelic:prod]
 monitor_mode = true
-
-# ---------------------------------------------------------------------------
-


### PR DESCRIPTION
At Hypothesis we use the names dev, qa and prod to identify our
development, staging/QA and production environments. The
`NEW_RELIC_ENVIRONMENT` value was set to these values in dev (by
`tox.ini`) and qa/prod (in the Elastic Beanstalk config). The
environment names in the New Relic config file did not match this
however, so the respective settings were not used.

This fixes an issue where Checkmate would spew a ton of New
Relic-related logging on startup in development, despite being
apparently configured to not monitor.