### PR TITLE
Re-enable New Relic transaction tracer

### DIFF
--- a/conf/newrelic.ini
+++ b/conf/newrelic.ini
@@ -8,10 +8,6 @@
 app_name = "checkmate"
 monitor_mode = true
 
-# Disable the transaction tracer due to suspected failures caused by cross
-# thread chatter: https://github.com/hypothesis/checkmate/issues/60
-transaction_tracer.enabled = false
-
 # Configuration overrides for specific environments
 
 [newrelic:dev]


### PR DESCRIPTION
This was disabled in an attempt to fix https://github.com/hypothesis/checkmate/issues/60 but the issue still occurred even when New Relic was disabled. This re-enables the setting per https://github.com/hypothesis/checkmate/issues/60#issuecomment-765389462 and https://github.com/hypothesis/checkmate/pull/296#pullrequestreview-635470127