### PR TITLE
Re-enable New Relic transaction tracing

### DIFF
--- a/conf/newrelic.ini
+++ b/conf/newrelic.ini
@@ -8,10 +8,6 @@
 app_name = "checkmate"
 monitor_mode = true
 
-# Disable the transaction tracer due to suspected failures caused by cross
-# thread chatter: https://github.com/hypothesis/checkmate/issues/60
-transaction_tracer.enabled = false
-
 # Configuration overrides for specific environments
 
 [newrelic:dev]


### PR DESCRIPTION
This was disabled to try to fix an issue:

* https://github.com/hypothesis/checkmate/issues/60
* https://github.com/hypothesis/checkmate/pull/83

But the "SSL error: decryption failed or bad record mac" crash is still happening in production.

* https://sentry.io/share/issue/d6a9cd75bf0e4a26963835984baf2e06/
* https://sentry.io/share/issue/434a72a65b2f402290d98fa0caa3b30c/
* https://sentry.io/share/issue/f8c25d28b2f946a8b286b324ff801ce4/