### PR TITLE
Use `tox-pip-sync` in place of `tox-pip-extensions`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,11 +9,10 @@ envlist = tests
 skipsdist = true
 minversion = 3.16.1
 requires =
-    tox-pip-extensions
+    tox-pip-sync
     tox-pyenv
     tox-run-command
     tox-envfile
-tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false
 
 [testenv]


### PR DESCRIPTION
For: https://github.com/hypothesis/tox-pip-sync/issues/5

Some local timings:

```
pip-sync
    fresh: 2m35s
    repeat: 1m00s
venv-update
    fresh:  2m11s
    repeat: 1m24s
```

So it looks like it's slower to create fresh envs, but quicker when repeating things, which if you had to choose is how you'd have it. Due to the time it takes to do these tests I've not repeated them much, so it could also be a fluke.

## Testing notes

* If you have a locally installed version of `tox-pip-sync` probably time to remove it
* I don't think you have to delete you tox envs, but if you run into trouble do.
* `make sure`