### PR TITLE
Tests should depend on `metadata`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,6 +24,7 @@ jobs:
 
   backend:
     name: Backend
+    needs: metadata
     runs-on: ubuntu-latest
     env:
       TOX_PARALLEL_NO_SPINNER: 1


### PR DESCRIPTION
For: https://github.com/hypothesis/product-backlog/issues/1199

I don't know why this is working, but it's wrong. We are probably getting a default version of python here.