### PR TITLE
Created release workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,9 @@
 name: Continuous integration
-on: pull_request
+
+on:
+  pull_request:
+  workflow_call:
+
 jobs:
   metadata:
     name: Metadata

--- a/.github/workflows/initial-release.yml
+++ b/.github/workflows/initial-release.yml
@@ -1,0 +1,38 @@
+# Perform initial stages of a Checkmate release.
+#
+# Once this is complete the prod_release workflow needs to be run to 
+# update production.
+name: initial-release
+
+concurrency:
+  group: ${{ github.event.repository.name }}-release
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  continuous-integration:
+    uses: ./.github/workflows/continuous-integration.yml
+    name: continuous integration
+
+  create-image:
+    needs: continuous-integration
+    uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
+    with:
+      Application: ${{ github.event.repository.name }}
+    secrets: inherit
+
+  qa:
+    needs: create-image
+    name: ${{ github.event.repository.name }}
+    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    with:
+      Application: ${{ github.event.repository.name }}
+      Environment: qa
+      Region: us-west-1
+      Operation: deploy
+      Version: latest
+    secrets: inherit

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -1,0 +1,27 @@
+# A manually triggered workflow that will install the `latest`
+# container version available for Checkmate on Docker Hub.
+#
+# To be run after a successful run of the initial_release workflow.
+#
+# The initial_release workflow deals with testing, creating a
+# Docker image and updating the QA service.
+name: prod-release
+
+concurrency:
+  group: ${{ github.event.repository.name }}-release
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+
+jobs:
+  prod:
+    name: ${{ github.event.repository.name }}
+    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    with:
+      Application: ${{ github.event.repository.name }}
+      Environment: prod
+      Region: us-west-1
+      Operation: deploy
+      Version: latest
+    secrets: inherit


### PR DESCRIPTION
**initial-release.yml**

Activated by an on-push event to the main branch. The release.yml
workflow automates the process of deploying updates to AWS Elastic
Beanstalk.

Due to the Checkmate repo being private we can not use environment
protection rules in GitHub to act as an approval service.

To work around this limitation the initial-release.yml workflow only
deals with updating the QA service. A secondary, manually trigger
workflow has been provided to update production

**prod-release.yml**

A manually triggered workflow that deals with updating the live
production service with the latest Checkmate container version available
on Docker Hub.

**continuous-integration.yml**

Updated to enabled it to be called by initial-release.yml

Part of the work towards: https://github.com/hypothesis/playbook/issues/929