### PR TITLE
Remove `tox-pip-sync`

### DIFF
--- a/requirements/checkformatting.in
+++ b/requirements/checkformatting.in
@@ -1,3 +1,4 @@
 pip-tools
+pip-sync-faster
 black
 isort

--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -22,8 +22,12 @@ pathspec==0.9.0
     # via black
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/checkformatting.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/checkformatting.in
+    #   pip-sync-faster
 platformdirs==2.5.2
     # via black
 pyparsing==3.0.9

--- a/requirements/coverage.in
+++ b/requirements/coverage.in
@@ -1,2 +1,3 @@
 pip-tools
+pip-sync-faster
 coverage

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -14,8 +14,12 @@ packaging==21.3
     # via build
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/coverage.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/coverage.in
+    #   pip-sync-faster
 pyparsing==3.0.9
     # via packaging
 tomli==2.0.1

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,5 +1,6 @@
 -r requirements.txt
 pip-tools
+pip-sync-faster
 ipython
 ipdb
 supervisor

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -170,8 +170,12 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/dev.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/dev.in
+    #   pip-sync-faster
 plaster==1.0
     # via
     #   -r requirements/requirements.txt

--- a/requirements/dockercompose.in
+++ b/requirements/dockercompose.in
@@ -1,2 +1,3 @@
 pip-tools
+pip-sync-faster
 docker-compose

--- a/requirements/dockercompose.txt
+++ b/requirements/dockercompose.txt
@@ -43,8 +43,12 @@ paramiko==2.10.1
     # via docker
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/dockercompose.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/dockercompose.in
+    #   pip-sync-faster
 pycparser==2.20
     # via cffi
 pynacl==1.4.0

--- a/requirements/format.in
+++ b/requirements/format.in
@@ -1,3 +1,4 @@
 pip-tools
+pip-sync-faster
 black
 isort

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -22,8 +22,12 @@ pathspec==0.9.0
     # via black
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/format.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/format.in
+    #   pip-sync-faster
 platformdirs==2.2.0
     # via black
 pyparsing==3.0.9

--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -1,4 +1,5 @@
 pip-tools
+pip-sync-faster
 httpretty
 pytest
 webtest

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -148,8 +148,12 @@ pastedeploy==2.1.1
     #   plaster-pastedeploy
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/functests.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/functests.in
+    #   pip-sync-faster
 plaster==1.0
     # via
     #   -r requirements/requirements.txt

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,4 +1,5 @@
 pip-tools
+pip-sync-faster
 pylint
 pydocstyle
 -r tests.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -215,10 +215,15 @@ pep517==0.13.0
     # via
     #   -r requirements/tests.txt
     #   build
+pip-sync-faster==0.0.2
+    # via
+    #   -r requirements/lint.in
+    #   -r requirements/tests.txt
 pip-tools==6.8.0
     # via
     #   -r requirements/lint.in
     #   -r requirements/tests.txt
+    #   pip-sync-faster
 plaster==1.0
     # via
     #   -r requirements/requirements.txt

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,4 +1,5 @@
 pip-tools
+pip-sync-faster
 coverage
 httpretty
 pytest

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -154,8 +154,12 @@ pastedeploy==2.1.1
     #   plaster-pastedeploy
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-sync-faster==0.0.2
     # via -r requirements/tests.in
+pip-tools==6.8.0
+    # via
+    #   -r requirements/tests.in
+    #   pip-sync-faster
 plaster==1.0
     # via
     #   -r requirements/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist = tests
 skipsdist = true
 minversion = 3.16.1
 requires =
-    tox-pip-sync
+    tox-faster
     tox-pyenv
     tox-run-command
     tox-envfile
@@ -58,6 +58,7 @@ whitelist_externals =
     dev: newrelic-admin
     {tests,functests}: sh
 commands =
+    pip-sync-faster requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     tests: sh bin/create-db checkmate_test
     functests: sh bin/create-db checkmate_functests


### PR DESCRIPTION
**Developers will have to `rm -rf .tox` in their dev envs after merging this** if they see `command not found: pip-sync-faster`.

Simplify our development tooling by removing the `tox-pip-sync` plugin in favour of calling [`pip-sync-faster`](https://github.com/hypothesis/pip-sync-faster) directly from `tox.ini`.

Also add the [`tox-faster`](https://github.com/hypothesis/tox-faster) plugin to `tox.ini`: `tox-faster` is a standalone implementation of a small `tox` speedup that was previously implemented in `tox-pip-sync`.

We did this in LMS a while ago and haven't noticed any problems there:

https://github.com/hypothesis/lms/pull/4191/files

Details
-------

* `pip-sync-faster` is added to all the `requirements/*.in` files (except the production `requirements/requirements.in`). `pip-sync-faster` needs to be installed in each tox env so that we can call it
* Ran `make requirements` to recompile the `requirements/*.txt` files from the changed `*.in`'s
* Replaced `tox-pip-sync` with `tox-faster` in the tox plugins in `tox.ini`
* Added a `pip-sync-faster` command to the top of the `commands` section in `tox.ini`

Testing
-------

* You'll need to run `rm -rf .tox` to get this working

* `make sure` should work

* If you repeatedly run a `tox` command you should see that it does not recreate or update the venv each time (`pip-sync-faster` does not call `pip-sync`). For example:

  ```terminal
  tox -e format
  ```

* If you change one of the `*.txt` files you should see that the next time you run tox it does update the venv (`pip-sync-faster` calls `pip-sync`, the output from `pip-sync` is obvious) and then subsequent runs after that do not update the venv again. Example:

  ```terminal
  echo flask >> requirements/format.in
  make requirements/format.txt
  tox -e format  # This will call pip-sync and update .tox/format.
  tox -e format  # Subsequent calls do not call pip-sync again.
  ```