### PR TITLE
Replace `h-checkmatelib` with just `checkmatelib`

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,6 +39,8 @@ charset-normalizer==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.0.3
     # via
     #   -r requirements/requirements.txt
@@ -83,8 +85,6 @@ greenlet==1.0.0
     #   sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.txt
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.txt
 hupper==1.10.2
@@ -103,7 +103,7 @@ importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
     #   alembic
-    #   h-checkmatelib
+    #   checkmatelib
     #   jsonschema
 ipdb==0.13.9
     # via -r requirements/dev.in
@@ -123,7 +123,7 @@ jinja2==2.11.3
 jsonschema==4.4.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 kombu==5.2.3
     # via
     #   -r requirements/requirements.txt
@@ -149,7 +149,7 @@ matplotlib-inline==0.1.2
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 oauthlib==3.1.0
@@ -247,7 +247,7 @@ pytz==2021.3
 requests==2.28.1
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -38,6 +38,8 @@ charset-normalizer==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.0.3
     # via
     #   -r requirements/requirements.txt
@@ -72,8 +74,6 @@ greenlet==1.0.0
     #   sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.txt
 h-matchers==1.2.15
     # via -r requirements/functests.in
 h-pyramid-sentry==1.2.3
@@ -96,7 +96,7 @@ importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
     #   alembic
-    #   h-checkmatelib
+    #   checkmatelib
     #   jsonschema
 iniconfig==1.1.1
     # via pytest
@@ -107,7 +107,7 @@ jinja2==2.11.3
 jsonschema==4.4.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 kombu==5.2.3
     # via
     #   -r requirements/requirements.txt
@@ -131,7 +131,7 @@ marshmallow-jsonapi==0.24.0
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 oauthlib==3.1.0
@@ -219,7 +219,7 @@ pytz==2021.3
 requests==2.28.1
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -54,6 +54,10 @@ charset-normalizer==2.0.1
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   requests
+checkmatelib==1.0.15
+    # via
+    #   -r requirements/requirements.txt
+    #   -r requirements/tests.txt
 click==8.0.3
     # via
     #   -r requirements/requirements.txt
@@ -107,10 +111,6 @@ gunicorn==20.1.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-h-checkmatelib==1.0.14
-    # via
-    #   -r requirements/requirements.txt
-    #   -r requirements/tests.txt
 h-matchers==1.2.15
     # via -r requirements/tests.txt
 h-pyramid-sentry==1.2.3
@@ -139,7 +139,7 @@ importlib-resources==5.9.0
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   alembic
-    #   h-checkmatelib
+    #   checkmatelib
     #   jsonschema
 iniconfig==1.1.1
     # via
@@ -156,7 +156,7 @@ jsonschema==4.4.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
 kombu==5.2.3
     # via
     #   -r requirements/requirements.txt
@@ -191,7 +191,7 @@ netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via
     #   -r requirements/requirements.txt
@@ -328,7 +328,7 @@ requests==2.28.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,7 +1,7 @@
 alembic
 celery
 gunicorn
-h-checkmatelib
+checkmatelib
 h-pyramid-sentry
 importlib_resources
 marshmallow-jsonapi

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,6 +22,8 @@ certifi==2020.11.8
     #   sentry-sdk
 charset-normalizer==2.0.1
     # via requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.in
 click==8.0.3
     # via
     #   celery
@@ -42,8 +44,6 @@ greenlet==1.0.0
     # via sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.in
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.in
 h-pyramid-sentry==1.2.3
     # via -r requirements/requirements.in
 hupper==1.10.2
@@ -56,12 +56,12 @@ importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.in
     #   alembic
-    #   h-checkmatelib
+    #   checkmatelib
     #   jsonschema
 jinja2==2.11.3
     # via pyramid-jinja2
 jsonschema==4.4.0
-    # via h-checkmatelib
+    # via checkmatelib
 kombu==5.2.3
     # via celery
 mako==1.1.3
@@ -76,7 +76,7 @@ marshmallow==3.10.0
 marshmallow-jsonapi==0.24.0
     # via -r requirements/requirements.in
 netaddr==0.8.0
-    # via h-checkmatelib
+    # via checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.in
 oauthlib==3.1.0
@@ -130,7 +130,7 @@ pytz==2021.3
 requests==2.28.1
     # via
     #   -r requirements/requirements.in
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via google-auth-oauthlib

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -38,6 +38,8 @@ charset-normalizer==2.0.1
     # via
     #   -r requirements/requirements.txt
     #   requests
+checkmatelib==1.0.15
+    # via -r requirements/requirements.txt
 click==8.0.3
     # via
     #   -r requirements/requirements.txt
@@ -78,8 +80,6 @@ greenlet==1.0.0
     #   sqlalchemy
 gunicorn==20.1.0
     # via -r requirements/requirements.txt
-h-checkmatelib==1.0.14
-    # via -r requirements/requirements.txt
 h-matchers==1.2.15
     # via -r requirements/tests.in
 h-pyramid-sentry==1.2.3
@@ -102,7 +102,7 @@ importlib-resources==5.9.0
     # via
     #   -r requirements/requirements.txt
     #   alembic
-    #   h-checkmatelib
+    #   checkmatelib
     #   jsonschema
 iniconfig==1.1.1
     # via pytest
@@ -113,7 +113,7 @@ jinja2==2.11.3
 jsonschema==4.4.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 kombu==5.2.3
     # via
     #   -r requirements/requirements.txt
@@ -137,7 +137,7 @@ marshmallow-jsonapi==0.24.0
 netaddr==0.8.0
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
 newrelic==8.0.0.179
     # via -r requirements/requirements.txt
 oauthlib==3.1.0
@@ -227,7 +227,7 @@ pytz==2021.3
 requests==2.28.1
     # via
     #   -r requirements/requirements.txt
-    #   h-checkmatelib
+    #   checkmatelib
     #   requests-oauthlib
 requests-oauthlib==1.3.0
     # via


### PR DESCRIPTION
`h-checkmatelib` has been renamed to just `checkmatelib`:

https://github.com/hypothesis/checkmatelib/pull/24

This commit is the result of replace `h-checkmatelib` with `checkmatelib` in `requirements.in` and then running `make requirements`.
