### PR TITLE
Set PYTHONPATH in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apk add --no-cache --virtual \
 
 COPY . .
 
+ENV PYTHONPATH /var/lib/hypothesis:$PYTHONPATH
+
 USER hypothesis
 
 CMD /usr/bin/supervisord -c /var/lib/hypothesis/conf/supervisord.conf


### PR DESCRIPTION
Fixes issues around executing alembic within the docker
process.


The problem we are seeing:

```
File "checkmate/migrations/env.py", line 11, in <module>
45
    from checkmate import models
46
ModuleNotFoundError: No module named 'checkmate'
47
failed to run commands: exit status 1
```

point to an issue around PYTHONPATH. 

That's  explicitly set on LMS (https://github.com/hypothesis/lms/blob/main/Dockerfile#L43) but not here.