### PR TITLE
Change to HTTPS for the devdata clone URL

### DIFF
--- a/bin/update_dev_data.py
+++ b/bin/update_dev_data.py
@@ -21,7 +21,7 @@ def update_remote_dev_data():
             [
                 "git",
                 "clone",
-                "git@github.com:hypothesis/devdata.git",
+                "https://github.com/hypothesis/devdata.git",
                 git_dir,
                 # Truncate the git history, we just want the files
                 "--depth=1",


### PR DESCRIPTION
The easiest way to set up Git->GitHub.com authentication nowadays is by
installing [GitHub CLI](https://cli.github.com/), running
[gh auth login](https://cli.github.com/manual/gh_auth_login), and
answering "Yes" (the default) when it asks "Authenticate Git with your
GitHub credentials?". By default this will set up authentication for
HTTPS git clone URLs but not SSH ones so `make devdata` will fail with
an authentication error because it tries to clone the private devdata
repo using the SSH clone URL.

Fix this by changing the devdata clone URL to the HTTPS one.
