### PR TITLE
Pin to tox<4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install tox
-      run: python -m pip install tox
+      run: python -m pip install 'tox<4'
 
     - name: Checkout git repo
       uses: actions/checkout@v2

--- a/bin/install-python
+++ b/bin/install-python
@@ -40,7 +40,7 @@ do
     # Install tox in this version of Python if it's not already installed.
     if ! "$(pyenv root)/versions/$python_version/bin/tox" --version > /dev/null 2>&1
     then
-        "$(pyenv root)/versions/$python_version/bin/pip" install --quiet --disable-pip-version-check tox > /dev/null
+        "$(pyenv root)/versions/$python_version/bin/pip" install --quiet --disable-pip-version-check 'tox<4' > /dev/null
         pyenv rehash
     fi
 done < .python-version

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ xfail_strict=true
 [tox]
 envlist = tests
 skipsdist = true
-minversion = 3.16.1
 requires =
+    tox>=3.16.1,<4
     tox-faster
     tox-pyenv
     tox-run-command


### PR DESCRIPTION
Pin to tox<4 to avoid breakage caused by tox 4.0.0 backwards-incompatibilities.

See https://github.com/hypothesis/cookiecutter-pyapp-test/pull/6 for details.
