### PR TITLE
Don't run workflows unnecessarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,14 @@ name: Continuous integration
 
 on:
   pull_request:
+    paths-ignore:
+      - '.cookiecutter/*'
+      - 'docs/*'
+      - 'requirements/*.in'
+      - 'requirements/dev.txt'
+      - '**/.gitignore'
+      - '*.md'
+      - 'LICENSE'
   workflow_call:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.cookiecutter/*'
+      - '.github/*'
+      - 'docs/*'
+      - 'requirements/*'
+      - '!requirements/requirements.txt'
+      - 'tests/*'
+      - '**/.gitignore'
+      - '*.md'
+      - 'tox.ini'
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Use `paths-ignore` to skip running the `ci.yml` and `deploy.yml` workflows for pull requests where the files modified make it unnecessary to run the workflow.  For example: don't run the tests on a PR that only modifies the documentation, or don't deploy a PR that only modifies development dependencies.

This should save us a lot of unnecessary workflow runs. For example we get a lot of Dependabot PRs for test and development dependencies, this will skip deploying any of those PRs.

This is as we've already done for h: https://github.com/hypothesis/h/pull/7755

GitHub's docs on this:

* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
