### PR TITLE
Update to actions/setup-python v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,30 +13,8 @@ on:
   workflow_call:
 
 jobs:
-  metadata:
-    name: Metadata
-    runs-on: ubuntu-latest
-    outputs:
-      python_headline_version: ${{ steps.list-python-versions.outputs.python_headline_version }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: List Python versions
-        id: list-python-versions
-        run: |
-          pip install hdev
-          echo "python_headline_version=`hdev python_version --style plain --first`" >> $GITHUB_OUTPUT
-
   backend:
     name: Backend
-    needs: metadata
     runs-on: ubuntu-latest
     env:
       TOX_PARALLEL_NO_SPINNER: 1
@@ -47,19 +25,19 @@ jobs:
         ports:
           - 5434:5432
     steps:
+    - name: Checkout git repo
+      uses: actions/checkout@v3
+
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: ${{ needs.metadata.outputs.python_headline_version }}
+        python-version-file: '.python-version'
 
     - name: Update pip
       run: python -m pip install --upgrade pip
 
     - name: Install tox
       run: python -m pip install 'tox<4'
-
-    - name: Checkout git repo
-      uses: actions/checkout@v3
 
     - name: Create test databases
       run: |


### PR DESCRIPTION
Update from `actions/setup-python@v2` to `@v4`, and used the new feature to read the python version from a local  `.python-version` file.