### PR TITLE
Fix Checkmate's `make dev`

### DIFF
--- a/checkmate/db.py
+++ b/checkmate/db.py
@@ -83,10 +83,11 @@ def _stamp_db(engine):  # pragma: no cover
     database after initializing it.
 
     """
-    try:
-        engine.execute("select 1 from alembic_version")
-    except sqlalchemy.exc.ProgrammingError:
-        alembic.command.stamp(alembic.config.Config("conf/alembic.ini"), "head")
+    with engine.connect() as connection:
+        try:
+            connection.execute(sqlalchemy.text("select 1 from alembic_version"))
+        except sqlalchemy.exc.ProgrammingError:
+            alembic.command.stamp(alembic.config.Config("conf/alembic.ini"), "head")
 
 
 def _session(request):  # pragma: no cover


### PR DESCRIPTION
The upgrade to SQLAlchemy (https://github.com/hypothesis/checkmate/pull/689) has broken `make dev` in Checkmate: the app no longer starts up at all in dev:

    $ make dev
    web (stderr) | [...] [577266] [ERROR] Exception in worker process
    web (stderr) | Traceback (most recent call last):
    ...
    web (stderr) | File ".../checkmate/checkmate/db.py", line 87, in _stamp_db
    web (stderr) |     engine.execute("select 1 from alembic_version")
    web (stderr) | AttributeError: 'Engine' object has no attribute 'execute'

There's no longer an `engine.execute()` method in SQLAlchemy 2. Instead you have to call `engine.connect()` to get a connection object and then call `connection.execute()`. See:

https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed

In addition you can't just pass a string of SQL to `connection.execute()`, you have to use `text()`.
