### PR TITLE
Run `ci.yml` after any push to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  push:
     paths-ignore:
       - '.cookiecutter/*'
       - 'docs/*'


### PR DESCRIPTION
Re-run `ci.yml` on `main` after merging a PR (or after pushing commits
directly to `main`). This is necessary for two reasons:

1. It updates GitHub Actions caches on `main` (which can be read from
   any PR branches), which saves time re-installing dependencies on PRs
2. It will send us a Slack notification if CI fails on `main`

This will enable us to remove the `ci.yml` call from `deploy.yml`.
