### PR TITLE
Wait for Postgres to start up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@ jobs:
         image: postgres:11.5-alpine
         ports:
           - 5434:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - name: Checkout git repo
       uses: actions/checkout@v3


### PR DESCRIPTION
We've been seeing the commands to create the databases failing on CI
with this error:

    psql: error: connection to server at "localhost" (::1), port 5437 failed: server closed the connection unexpectedly
            This probably means the server terminated abnormally
            before or while processing the request.

The problem looks like a race condition between starting the Postgres
docker container and the command that creates the DB: we're trying to
create the DB before Postgres has finished starting up.

Fix this by setting Postgres docker container options that cause it to
wait for Postgres to be up and running before continuing.

See:

https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers#running-jobs-in-containers

Also adding the `POSTGRES_HOST_AUTH_METHOD` envvar that our other repos
have. This was needed in our other repos in order for recent versions of
Postgres to actually start up successfully. I'm not sure how Checkmate
is getting away without it currently.
