### PR TITLE
Reorganise Checkmate's Gunicorn config

### DIFF
--- a/conf/gunicorn-dev.conf.py
+++ b/conf/gunicorn-dev.conf.py
@@ -1,0 +1,4 @@
+bind = "0.0.0.0:9099"
+reload = True
+reload_extra_files = "checkmate/templates"
+timeout = 0

--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -1,0 +1,2 @@
+bind = "0.0.0.0:9099"
+worker_tmp_dir = "/dev/shm"

--- a/conf/gunicorn/dev.conf.py
+++ b/conf/gunicorn/dev.conf.py
@@ -1,6 +1,0 @@
-# Configuration settings for Gunicorn in dev
-
-workers = 4
-reload = True
-bind = "0.0.0.0:9099"
-timeout = 0

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -1,0 +1,42 @@
+[pipeline:main]
+pipeline:
+  proxy-prefix
+  checkmate
+
+[app:checkmate]
+use = call:checkmate.app:create_app
+
+[filter:proxy-prefix]
+use: egg:PasteDeploy#prefix
+
+[loggers]
+keys = root, checkmate, alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_checkmate]
+level = DEBUG
+handlers =
+qualname = checkmate
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -3,7 +3,7 @@ nodaemon = true
 silent = true
 
 [program:web]
-command=newrelic-admin run-program gunicorn -c conf/gunicorn/dev.conf.py --paste conf/development.ini
+command=newrelic-admin run-program gunicorn --paste conf/development.ini --config conf/gunicorn-dev.conf.py
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:web]
-command=newrelic-admin run-program gunicorn checkmate.app:create_app() --bind 0.0.0.0:9099
+command=newrelic-admin run-program gunicorn --paste conf/production.ini --config conf/gunicorn.conf.py
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ setenv =
     dev: PUBLIC_PORT = {env:PUBLIC_PORT:9099}
     dev: CHECKMATE_SECRET = not_a_secret
     dev: CHECKMATE_API_KEY_DEV = dev_api_key
+    dev: WEB_CONCURRENCY = {env:WEB_CONCURRENCY:2}
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
 
 passenv =


### PR DESCRIPTION
This reorganise's Checkmate's Gunicorn config files following the same
pattern as was recently done in h:

https://github.com/hypothesis/h/pull/8407

I'm applying this simpler and more explicit Gunicorn config approach to
all our apps consistently. For motivation see:

https://docs.google.com/document/d/13AnUPtu9AO3PfRm-fhH7_3RZzyLGSFd4uPv36dIeynA

Benefits:

* Gunicorn config files are explicitly mentioned in the `gunicorn`
  commands in the `supervisord[-dev].conf` files. This makes things less
  confusing/surprising, less likely that a Gunicorn config file will be
  missed (compared to Gunicorn's default behavior if you run it without
  a `--config` argument: it reads any `gunicorn.conf.py` file in the
  current working directory).

* The Gunicorn config files are in the `conf/` directory with the other
  config files. Again: makes it less likely that a config file will go
  unnoticed.

* Separate production and development Gunicorn config files. This is
  consistent with our separate production and development Pyramid config
  files, and is probably a good idea to prevent development settings
  accidentally getting applied in production. (Gunicorn's default
  behavior of reading a root `gunicorn.conf.py` file would mean that
  file gets read in both dev and production).
