### PR TITLE
Upgrade  postgres to 15.6 in preparation for the production upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11.5-alpine
+        image: postgres:15.6-alpine
         ports:
           - 5434:5432
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:11.5-alpine
+    image: postgres:15.6-alpine
     ports:
       - '127.0.0.1:5434:5432'
     healthcheck:


### PR DESCRIPTION
For:

- https://github.com/hypothesis/playbook/issues/1147

## Testing and local env setup

If you don't have the service running you can just

`make services dev`

and the right postgres version will start.


If you do have a container running the upgrade will stop not upgrade it's contents, we can nuke the current postgres volume:


- Find the the volume ID:

```
docker inspect -f '{{ .Mounts }}' checkmate-postgres-1
[{volume e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076 /var/lib/docker/volumes/e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076/_data /var/lib/postgresql/data local  true }]
```

- Stop the container

`docker compose down`


- And remove the volume:

`docker volume rm e22d1a81e263ceb8a63b29a14bc7ec2dbe9f023e7c05742cba6694a4999a6076`


- Start the DB and server

`make services dev`
