### PR TITLE
Add missing POSTGRES_HOST_AUTH_METHOD for docker postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     healthcheck:
         test: ["CMD", "pg_isready", "-U", "postgres"]
         interval: 1s
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
   rabbit:
     image: rabbitmq:3.12-management-alpine
     ports:


### PR DESCRIPTION
Missing in: https://github.com/hypothesis/checkmate/pull/847