### PR TITLE
Correct Postgres version in dev and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15.6-alpine
+        image: postgres:15.5-alpine
         ports:
           - 5434:5432
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:15.6-alpine
+    image: postgres:15.5-alpine
     ports:
       - '127.0.0.1:5434:5432'
     healthcheck:


### PR DESCRIPTION
Checkmate's staging and production environments use Postgres 15.5, not
15.6.
