### PR TITLE
Add an admin page for adding urls

### DIFF
--- a/checkmate/routes.py
+++ b/checkmate/routes.py
@@ -13,8 +13,10 @@ def add_routes(config):
     config.add_static_view("static", "static/static", cache_max_age=3600)
 
     config.add_route("present_block", "/block")
-    config.add_route("admin_pages", "/admin")
-    config.add_route("admin_allow_rule", "/admin/allow_rule")
+
+    config.add_route("admin.index", "/admin/")
+    config.add_route("admin.pages", "/admin/pages/")
+    config.add_route("admin.allow_rule", "/admin/allow_rule/")
 
     config.add_route("add_to_allow_list", "/api/rule", request_method="POST")
 

--- a/checkmate/routes.py
+++ b/checkmate/routes.py
@@ -14,6 +14,7 @@ def add_routes(config):
 
     config.add_route("present_block", "/block")
     config.add_route("admin_pages", "/admin")
+    config.add_route("admin_allow_rule", "/admin/allow_rule")
 
     config.add_route("add_to_allow_list", "/api/rule", request_method="POST")
 

--- a/checkmate/templates/admin/allow_rule.html.jinja2
+++ b/checkmate/templates/admin/allow_rule.html.jinja2
@@ -1,26 +1,26 @@
 {% extends "checkmate:templates/admin/base.html.jinja2" %}
 {% block content %}
 
-<h2>Add to Allow List</h2>
+  <h2>Add to Allow List</h2>
 
-{% if messages %}
-  <div>
-    {% for message in messages %}
-      <p>{{ message.detail }}</p>
-    {% endfor %}
-  </div>
-{% endif %}
+  {% if messages %}
+    <div>
+      {% for message in messages %}
+        <p>{{ message.detail }}</p>
+      {% endfor %}
+    </div>
+  {% endif %}
 
-{% if allow_rule %}
-  <p>Allowed as {{ allow_rule.rule }} with hash {{ allow_rule.hash }}</p>
-{% endif %}
+  {% if allow_rule %}
+    <p>Allowed as {{ allow_rule.rule }} with hash {{ allow_rule.hash }}</p>
+  {% endif %}
 
-<form action="{{ request.route_url('admin.allow_rule') }}" method="post">
-  <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
-  <label>
-    <input type="url" name="url" placeholder="URL" size="100">
-  </label>
-  <input type="submit" value="Submit">
-</form>
+  <form action="{{ request.route_url('admin.allow_rule') }}" method="post">
+    <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+    <label>
+      <input type="url" name="url" placeholder="URL" size="100">
+    </label>
+    <input type="submit" value="Submit">
+  </form>
 
 {% endblock %}

--- a/checkmate/templates/admin/allow_rule.html.jinja2
+++ b/checkmate/templates/admin/allow_rule.html.jinja2
@@ -1,0 +1,27 @@
+<style>
+    code {
+        word-break: break-all;
+    }
+</style>
+
+<h2>Add to Allow List</h2>
+
+{% if messages %}
+  <div>
+    {% for message in messages %}
+      <p>{{ message.detail }}</p>
+    {% endfor %}
+  </div>
+{% endif %}
+
+{% if allow_rule %}
+  <p>Allowed as {{ allow_rule.rule }} with hash {{ allow_rule.hash }}</p>
+{% endif %}
+
+<form action="{{ request.route_url('admin_allow_rule') }}" method="post">
+  <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+  <label>
+    <input type="url" name="url" placeholder="URL">
+  </label>
+  <input type="submit" value="Submit">
+</form>

--- a/checkmate/templates/admin/allow_rule.html.jinja2
+++ b/checkmate/templates/admin/allow_rule.html.jinja2
@@ -15,7 +15,7 @@
   <p>Allowed as {{ allow_rule.rule }} with hash {{ allow_rule.hash }}</p>
 {% endif %}
 
-<form action="{{ request.route_url('admin_allow_rule') }}" method="post">
+<form action="{{ request.route_url('admin.allow_rule') }}" method="post">
   <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
   <label>
     <input type="url" name="url" placeholder="URL" size="100">

--- a/checkmate/templates/admin/allow_rule.html.jinja2
+++ b/checkmate/templates/admin/allow_rule.html.jinja2
@@ -1,8 +1,5 @@
-<style>
-    code {
-        word-break: break-all;
-    }
-</style>
+{% extends "checkmate:templates/admin/base.html.jinja2" %}
+{% block content %}
 
 <h2>Add to Allow List</h2>
 
@@ -21,7 +18,9 @@
 <form action="{{ request.route_url('admin_allow_rule') }}" method="post">
   <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
   <label>
-    <input type="url" name="url" placeholder="URL">
+    <input type="url" name="url" placeholder="URL" size="100">
   </label>
   <input type="submit" value="Submit">
 </form>
+
+{% endblock %}

--- a/checkmate/templates/admin/base.html.jinja2
+++ b/checkmate/templates/admin/base.html.jinja2
@@ -1,0 +1,24 @@
+<style>
+    code {
+        word-break: break-all;
+    }
+    nav ul {
+        display: flex;
+        list-style-type: none;
+        padding: 0;
+    }
+    nav ul li {
+        margin-right: 15px;
+    }
+</style>
+
+<nav>
+  <ul>
+    <li><a href="{{ request.route_url('admin_pages') }}">Admin</a></li>
+    <li><a href="{{ request.route_url('admin_allow_rule') }}">Allow Rule</a></li>
+    <li><a href="{{ request.route_url("pyramid_googleauth.logout") }}">Logout</a></li>
+  </ul>
+</nav>
+
+{% block content %}
+{% endblock %}

--- a/checkmate/templates/admin/base.html.jinja2
+++ b/checkmate/templates/admin/base.html.jinja2
@@ -22,8 +22,9 @@
 
 <nav>
   <ul>
-    <li><a href="{{ request.route_url('admin_pages') }}">Admin</a></li>
-    <li><a href="{{ request.route_url('admin_allow_rule') }}">Allow Rule</a></li>
+    <li><a href="{{ request.route_url('admin.index') }}">Admin</a></li>
+    <li><a href="{{ request.route_url('admin.pages') }}">Pages</a></li>
+    <li><a href="{{ request.route_url('admin.allow_rule') }}">Allow Rule</a></li>
     <li><a href="{{ request.route_url("pyramid_googleauth.logout") }}">Logout</a></li>
   </ul>
 </nav>

--- a/checkmate/templates/admin/base.html.jinja2
+++ b/checkmate/templates/admin/base.html.jinja2
@@ -1,16 +1,24 @@
-<style>
-    code {
-        word-break: break-all;
-    }
-    nav ul {
-        display: flex;
-        list-style-type: none;
-        padding: 0;
-    }
-    nav ul li {
-        margin-right: 15px;
-    }
-</style>
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Checkmate Admin</title>
+  <style>
+      code {
+          word-break: break-all;
+      }
+
+      nav ul {
+          display: flex;
+          list-style-type: none;
+          padding: 0;
+      }
+
+      nav ul li {
+          margin-right: 15px;
+      }
+  </style>
+</head>
+<body>
 
 <nav>
   <ul>
@@ -22,3 +30,6 @@
 
 {% block content %}
 {% endblock %}
+
+</body>
+</html>

--- a/checkmate/templates/admin/pages.html.jinja2
+++ b/checkmate/templates/admin/pages.html.jinja2
@@ -1,8 +1,5 @@
-<style>
-    code {
-        word-break: break-all;
-    }
-</style>
+{% extends "checkmate:templates/admin/base.html.jinja2" %}
+{% block content %}
 
 <h1>Hello {{ request.session.user.name }}</h1>
 
@@ -22,6 +19,4 @@
 <h2>Add to allow list</h2>
 
 <code>tox -qe dev --run-command "python bin/add_to_allow_list.py --session={{ session }} --route={{ request.route_url('add_to_allow_list') }}"</code>
-
-<hr>
-<a href="{{ request.route_url("pyramid_googleauth.logout") }}">Logout</a>
+{%  endblock %}

--- a/checkmate/templates/admin/pages.html.jinja2
+++ b/checkmate/templates/admin/pages.html.jinja2
@@ -21,7 +21,6 @@
 
 <h2>Add to allow list</h2>
 
-
 <code>tox -qe dev --run-command "python bin/add_to_allow_list.py --session={{ session }} --route={{ request.route_url('add_to_allow_list') }}"</code>
 
 <hr>

--- a/checkmate/views/ui/admin.py
+++ b/checkmate/views/ui/admin.py
@@ -45,18 +45,23 @@ class AdminPagesViews:
 
 @view_defaults(
     route_name="admin.allow_rule",
-    permission=Permissions.ADMIN,
     renderer="checkmate:templates/admin/allow_rule.html.jinja2",
 )
 class AdminAllowRuleViews:
     def __init__(self, request):
         self.request = request
 
-    @view_config(request_method="GET")
+    @view_config(
+        request_method="GET",
+        permission=Permissions.ADMIN,
+    )
     def get(self):
         return {}
 
-    @view_config(request_method="POST")
+    @view_config(
+        request_method="POST",
+        permission=Permissions.ADMIN,
+    )
     def post(self):
         url = self.request.params["url"]
         try:
@@ -64,3 +69,7 @@ class AdminAllowRuleViews:
         except ResourceConflict as e:
             return {"messages": e.messages}
         return {"allow_rule": allow_rule}
+
+    @forbidden_view_config()
+    def logged_out(self):
+        return HTTPFound(location=self.request.route_url("pyramid_googleauth.login"))

--- a/checkmate/views/ui/admin.py
+++ b/checkmate/views/ui/admin.py
@@ -63,7 +63,9 @@ class AdminAllowRuleViews:
         permission=Permissions.ADMIN,
     )
     def post(self):
-        url = self.request.params["url"]
+        url = self.request.params.get("url")
+        if not url:
+            return {"messages": [{"detail": "URL is required"}]}
         try:
             allow_rule = self.request.find_service(RuleService).add_to_allow_list(url)
         except ResourceConflict as e:

--- a/checkmate/views/ui/admin.py
+++ b/checkmate/views/ui/admin.py
@@ -8,7 +8,7 @@ from pyramid.view import (
     view_defaults,
 )
 
-from checkmate.exceptions import JSONAPIException
+from checkmate.exceptions import ResourceConflict
 from checkmate.security import Permissions
 from checkmate.services import RuleService
 
@@ -61,6 +61,6 @@ class AdminAllowRuleViews:
         url = self.request.params["url"]
         try:
             allow_rule = self.request.find_service(RuleService).add_to_allow_list(url)
-        except JSONAPIException as e:
+        except ResourceConflict as e:
             return {"messages": e.messages}
         return {"allow_rule": allow_rule}

--- a/checkmate/views/ui/admin.py
+++ b/checkmate/views/ui/admin.py
@@ -3,7 +3,9 @@ from http.cookies import SimpleCookie
 from pyramid.httpexceptions import HTTPFound
 from pyramid.view import forbidden_view_config, view_config, view_defaults
 
+from checkmate.exceptions import JSONAPIException
 from checkmate.security import Permissions
+from checkmate.services import RuleService
 
 
 @view_defaults(route_name="admin_pages", request_method="GET")
@@ -24,3 +26,26 @@ class AdminPagesViews:
     @forbidden_view_config()
     def logged_out(self):
         return HTTPFound(location=self.request.route_url("pyramid_googleauth.login"))
+
+
+@view_defaults(
+    route_name="admin_allow_rule",
+    permission=Permissions.ADMIN,
+    renderer="checkmate:templates/admin/allow_rule.html.jinja2",
+)
+class AdminAllowViews:
+    def __init__(self, request):
+        self.request = request
+
+    @view_config(request_method="GET")
+    def get(self):
+        return {}
+
+    @view_config(request_method="POST")
+    def post(self):
+        url = self.request.params["url"]
+        try:
+            allow_rule = self.request.find_service(RuleService).add_to_allow_list(url)
+        except JSONAPIException as e:
+            return {"messages": e.messages}
+        return {"allow_rule": allow_rule}

--- a/checkmate/views/ui/admin.py
+++ b/checkmate/views/ui/admin.py
@@ -48,7 +48,7 @@ class AdminPagesViews:
     permission=Permissions.ADMIN,
     renderer="checkmate:templates/admin/allow_rule.html.jinja2",
 )
-class AdminAllowViews:
+class AdminAllowRuleViews:
     def __init__(self, request):
         self.request = request
 

--- a/checkmate/views/ui/admin.py
+++ b/checkmate/views/ui/admin.py
@@ -1,14 +1,29 @@
 from http.cookies import SimpleCookie
 
-from pyramid.httpexceptions import HTTPFound
-from pyramid.view import forbidden_view_config, view_config, view_defaults
+from pyramid.httpexceptions import HTTPFound, HTTPNotFound
+from pyramid.view import (
+    forbidden_view_config,
+    notfound_view_config,
+    view_config,
+    view_defaults,
+)
 
 from checkmate.exceptions import JSONAPIException
 from checkmate.security import Permissions
 from checkmate.services import RuleService
 
 
-@view_defaults(route_name="admin_pages", request_method="GET")
+@view_config(route_name="admin.index")
+def index(request):
+    return HTTPFound(location=request.route_url("admin.allow_rule"))
+
+
+@notfound_view_config(path_info="/admin/*", append_slash=True)
+def notfound(_request):
+    return HTTPNotFound()
+
+
+@view_defaults(route_name="admin.pages", request_method="GET")
 class AdminPagesViews:
     def __init__(self, request):
         self.request = request
@@ -29,7 +44,7 @@ class AdminPagesViews:
 
 
 @view_defaults(
-    route_name="admin_allow_rule",
+    route_name="admin.allow_rule",
     permission=Permissions.ADMIN,
     renderer="checkmate:templates/admin/allow_rule.html.jinja2",
 )

--- a/tests/functional/checkmate/views/ui/admin_test.py
+++ b/tests/functional/checkmate/views/ui/admin_test.py
@@ -7,13 +7,13 @@ class TestAdminPages:
     def test_if_youre_not_logged_in_it_redirects_to_the_login_page(
         self, app, route_url
     ):
-        response = app.get("/admin")
+        response = app.get("/admin/pages/")
 
         assert response == temporary_redirect_to(route_url("pyramid_googleauth.login"))
 
     @pytest.mark.usefixtures("logged_in")
     def test_if_you_are_logged_in_it_passes_your_cookie_to_the_template(self, app):
-        response = app.get("/admin", status=200)
+        response = app.get("/admin/pages/", status=200)
 
         assert response.content_type == "text/html"
         assert app.cookies["session"].encode() in response.body

--- a/tests/functional/checkmate/views/ui/admin_test.py
+++ b/tests/functional/checkmate/views/ui/admin_test.py
@@ -22,3 +22,19 @@ class TestAdminPages:
 class TestAdminLoginFailure:
     def test_it(self, app):
         app.get("/googleauth/login/failure", status=401)
+
+
+@pytest.mark.usefixtures("logged_in")
+class TestAdminAllowRule:
+    def test_allow_rule_form_renders_correctly(self, app):
+        response = app.get("/admin/allow_rule/", status=200)
+
+        assert response.content_type == "text/html"
+
+    def test_post_allow_rule_form_submission(self, app):
+        response = app.post(
+            "/admin/allow_rule/", status=200, params={"url": "http://google.com"}
+        )
+
+        assert response.content_type == "text/html"
+        assert "Allowed as google.com/" in response.text

--- a/tests/functional/checkmate/views/ui/api/add_to_allow_list_test.py
+++ b/tests/functional/checkmate/views/ui/api/add_to_allow_list_test.py
@@ -22,7 +22,7 @@ class TestAddToAllowList:
                     "rule": "example.com/",
                     "tags": ["manual"],
                 },
-                "id": 1,
+                "id": response.json["data"]["id"],
                 "type": "AllowRule",
             }
         }

--- a/tests/unit/checkmate/views/ui/admin_test.py
+++ b/tests/unit/checkmate/views/ui/admin_test.py
@@ -1,7 +1,26 @@
 import pytest
 
-from checkmate.views.ui.admin import AdminPagesViews
+from checkmate.views.ui.admin import (
+    AdminAllowRuleViews,
+    AdminPagesViews,
+    index,
+    notfound,
+)
 from tests.unit.matchers import temporary_redirect_to
+
+
+def test_admin_index(pyramid_request):
+    response = index(pyramid_request)
+
+    assert response == temporary_redirect_to(
+        pyramid_request.route_url("admin.allow_rule")
+    )
+
+
+def test_not_found_view(pyramid_request):
+    response = notfound(pyramid_request)
+
+    assert response.status_code == 404
 
 
 class TestAdminPagesViews:
@@ -22,3 +41,24 @@ class TestAdminPagesViews:
     @pytest.fixture
     def views(self, pyramid_request):
         return AdminPagesViews(pyramid_request)
+
+
+class TestAdminAllowRuleViews:
+    def test_get(self, views):
+        response = views.get()
+
+        assert response == {}
+
+    def test_post(self, pyramid_request, views, rule_service):
+        pyramid_request.params["url"] = "http://example.com"
+
+        response = views.post()
+
+        rule_service.add_to_allow_list.assert_called_once_with("http://example.com")
+        assert response == {
+            "allow_rule": rule_service.add_to_allow_list.return_value,
+        }
+
+    @pytest.fixture
+    def views(self, pyramid_request):
+        return AdminAllowRuleViews(pyramid_request)

--- a/tests/unit/checkmate/views/ui/admin_test.py
+++ b/tests/unit/checkmate/views/ui/admin_test.py
@@ -59,6 +59,6 @@ class TestAdminAllowRuleViews:
             "allow_rule": rule_service.add_to_allow_list.return_value,
         }
 
-    @pytest.fixture
+    @pytest.fixture()
     def views(self, pyramid_request):
         return AdminAllowRuleViews(pyramid_request)

--- a/tests/unit/checkmate/views/ui/admin_test.py
+++ b/tests/unit/checkmate/views/ui/admin_test.py
@@ -74,6 +74,13 @@ class TestAdminAllowRuleViews:
         )
         assert response == {"messages": exception.messages}
 
+    def test_logged_out_redirects_to_login(self, pyramid_request, views):
+        response = views.logged_out()
+
+        assert response == temporary_redirect_to(
+            pyramid_request.route_url("pyramid_googleauth.login")
+        )
+
     @pytest.fixture()
     def views(self, pyramid_request):
         return AdminAllowRuleViews(pyramid_request)

--- a/tests/unit/checkmate/views/ui/admin_test.py
+++ b/tests/unit/checkmate/views/ui/admin_test.py
@@ -62,6 +62,14 @@ class TestAdminAllowRuleViews:
             "allow_rule": rule_service.add_to_allow_list.return_value,
         }
 
+    def test_post_empty_url(self, pyramid_request, views, rule_service):
+        pyramid_request.params["url"] = ""
+
+        response = views.post()
+
+        rule_service.add_to_allow_list.assert_not_called()
+        assert response == {"messages": [{"detail": "URL is required"}]}
+
     def test_post_with_conflict(self, pyramid_request, views, rule_service):
         pyramid_request.params["url"] = "http://example.com"
         exception = ResourceConflict("conflict")


### PR DESCRIPTION
Fixes #919 

This PR only adds a form to add new urls without removing the old api and script.

Testing
-------

1. Log in as devdata_admin (password: pass).

2. Go to `http://localhost:9099/admin/` which will redirect to `/admin/allow_rule/`.

3. Type in a URL (e.g. `http://example.com`) and click the "Submit" button to add it to the list of allowed URLs.

4. Type in the same URL again and click the "Submit" button to see an error message.