### PR TITLE
Fix admin allow URL html

### DIFF
--- a/checkmate/routes.py
+++ b/checkmate/routes.py
@@ -15,7 +15,7 @@ def add_routes(config):
     config.add_route("present_block", "/block")
 
     config.add_route("admin.index", "/admin/")
-    config.add_route("admin.allow_rule", "/admin/allow_rule/")
+    config.add_route("admin.allow_url", "/admin/allow_url/")
 
     config.add_route("add_to_allow_list", "/api/rule", request_method="POST")
 

--- a/checkmate/templates/admin/allow_rule.html.jinja2
+++ b/checkmate/templates/admin/allow_rule.html.jinja2
@@ -1,26 +1,63 @@
 {% extends "checkmate:templates/admin/base.html.jinja2" %}
 {% block content %}
 
-  <h2>Add to Allow List</h2>
+  <section>
+    <div class="container">
+      {% if messages %}
+        <article class="message is-danger">
+          <div class="message-body">
+            {% for message in messages %}
+              <p>{{ message.detail }}</p>
+            {% endfor %}
+          </div>
+        </article>
+      {% endif %}
 
-  {% if messages %}
-    <div>
-      {% for message in messages %}
-        <p>{{ message.detail }}</p>
-      {% endfor %}
+      {% if allow_rule %}
+        <article class="message">
+          <div class="message-body">
+            <p>Allowed as {{ allow_rule.rule }} with hash {{ allow_rule.hash }}</p>
+          </div>
+        </article>
+      {% endif %}
     </div>
-  {% endif %}
+  </section>
 
-  {% if allow_rule %}
-    <p>Allowed as {{ allow_rule.rule }} with hash {{ allow_rule.hash }}</p>
-  {% endif %}
+  <section>
+    <div class="container">
+      <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Add to Allow List</legend>
+        <form action="{{ request.route_url('admin.allow_rule') }}" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
-  <form action="{{ request.route_url('admin.allow_rule') }}" method="post">
-    <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
-    <label>
-      <input type="url" name="url" placeholder="URL" size="100">
-    </label>
-    <input type="submit" value="Submit">
-  </form>
+          <div class="field is-horizontal">
+            <div class="field-label is-normal">
+              <label class="label">URL</label>
+            </div>
+            <div class="field-body">
+              <div class="field">
+                <div class="control is-expanded">
+                  <input class="input" name="url" type="text" placeholder="URL" size="100">
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="field is-horizontal">
+            <div class="field-label is-normal">
+              <label class="label"></label>
+            </div>
+            <div class="field-body">
+              <div class="field">
+                <div class="control is-expanded">
+                  <input type="submit" class="button is-info" value="Add">
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </fieldset>
+    </div>
+  </section>
 
 {% endblock %}

--- a/checkmate/templates/admin/allow_url.html.jinja2
+++ b/checkmate/templates/admin/allow_url.html.jinja2
@@ -27,7 +27,7 @@
     <div class="container">
       <fieldset class="box mt-6">
         <legend class="label has-text-centered">Add to Allow List</legend>
-        <form action="{{ request.route_url('admin.allow_rule') }}" method="POST">
+        <form action="{{ request.route_url("admin.allow_url") }}" method="POST">
           <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
 
           <div class="field is-horizontal">

--- a/checkmate/templates/admin/base.html.jinja2
+++ b/checkmate/templates/admin/base.html.jinja2
@@ -9,7 +9,6 @@
           crossorigin="anonymous"
           referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/@vizuaalog/bulmajs@0.12.2/dist/bulma.min.js"></script>
-
 </head>
 <body>
 

--- a/checkmate/templates/admin/base.html.jinja2
+++ b/checkmate/templates/admin/base.html.jinja2
@@ -2,30 +2,37 @@
 <html lang="en">
 <head>
   <title>Checkmate Admin</title>
-  <style>
-      code {
-          word-break: break-all;
-      }
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.15.2/js/selectize.min.js"
+          integrity="sha512-IOebNkvA/HZjMM7MxL0NYeLYEalloZ8ckak+NDtOViP7oiYzG5vn6WVXyrJDiJPhl4yRdmNAG49iuLmhkUdVsQ=="
+          crossorigin="anonymous"
+          referrerpolicy="no-referrer"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@vizuaalog/bulmajs@0.12.2/dist/bulma.min.js"></script>
 
-      nav ul {
-          display: flex;
-          list-style-type: none;
-          padding: 0;
-      }
-
-      nav ul li {
-          margin-right: 15px;
-      }
-  </style>
 </head>
 <body>
 
-<nav>
-  <ul>
-    <li><a href="{{ request.route_url("admin.index") }}">Admin</a></li>
-    <li><a href="{{ request.route_url("admin.allow_rule") }}">Allow Rule</a></li>
-    <li><a href="{{ request.route_url("pyramid_googleauth.logout") }}">Logout</a></li>
-  </ul>
+<nav class="navbar is-dark" role="navigation" aria-label="main navigation">
+  <div class="navbar-brand">
+    <a class="navbar-item" href="{{ request.route_url("admin.index") }}">
+      <p class="is-size-4">ADMIN</p>
+    </a>
+  </div>
+  <div class="navbar-menu is-active">
+    <div class="navbar-start" style="flex-grow: 1; justify-content: center;">
+      <a class="navbar-item"
+         href="{{ request.route_url("admin.allow_rule") }}">Allow URL</a>
+      <div class="navbar-end">
+        <div class="navbar-item">
+          <div class="buttons">
+            <a class="button is-light"
+               href="{{ request.route_url("pyramid_googleauth.logout") }}">Log out</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </nav>
 
 {% block content %}

--- a/checkmate/templates/admin/base.html.jinja2
+++ b/checkmate/templates/admin/base.html.jinja2
@@ -21,7 +21,7 @@
   <div class="navbar-menu is-active">
     <div class="navbar-start" style="flex-grow: 1; justify-content: center;">
       <a class="navbar-item"
-         href="{{ request.route_url("admin.allow_rule") }}">Allow URL</a>
+         href="{{ request.route_url("admin.allow_url") }}">Allow URL</a>
       <div class="navbar-end">
         <div class="navbar-item">
           <div class="buttons">

--- a/checkmate/views/admin.py
+++ b/checkmate/views/admin.py
@@ -13,7 +13,7 @@ from checkmate.services import RuleService
 
 @view_config(route_name="admin.index")
 def index(request):
-    return HTTPFound(location=request.route_url("admin.allow_rule"))
+    return HTTPFound(location=request.route_url("admin.allow_url"))
 
 
 @notfound_view_config(path_info="/admin/*", append_slash=True)
@@ -22,8 +22,8 @@ def notfound(_request):
 
 
 @view_defaults(
-    route_name="admin.allow_rule",
-    renderer="checkmate:templates/admin/allow_rule.html.jinja2",
+    route_name="admin.allow_url",
+    renderer="checkmate:templates/admin/allow_url.html.jinja2",
 )
 class AdminAllowRuleViews:
     def __init__(self, request):

--- a/conf/gunicorn-dev.conf.py
+++ b/conf/gunicorn-dev.conf.py
@@ -1,4 +1,6 @@
+from glob import glob
+
 bind = "0.0.0.0:9099"
 reload = True
-reload_extra_files = "checkmate/templates"
+reload_extra_files = glob("checkmate/templates/**/*", recursive=True)
 timeout = 0

--- a/tests/functional/checkmate/views/admin_test.py
+++ b/tests/functional/checkmate/views/admin_test.py
@@ -8,24 +8,24 @@ class TestAdminLoginFailure:
         app.get("/googleauth/login/failure", status=401)
 
 
-class TestAdminAllowRule:
+class TestAdminAllowURL:
     def test_if_youre_not_logged_in_it_redirects_to_the_login_page(
         self, app, route_url
     ):
-        response = app.get("/admin/allow_rule/")
+        response = app.get("/admin/allow_url/")
 
         assert response == temporary_redirect_to(route_url("pyramid_googleauth.login"))
 
     @pytest.mark.usefixtures("logged_in")
-    def test_allow_rule_form_renders_correctly(self, app):
-        response = app.get("/admin/allow_rule/", status=200)
+    def test_form_renders_correctly(self, app):
+        response = app.get("/admin/allow_url/", status=200)
 
         assert response.content_type == "text/html"
 
     @pytest.mark.usefixtures("logged_in")
-    def test_post_allow_rule_form_submission(self, app):
+    def test_post_form_submission(self, app):
         response = app.post(
-            "/admin/allow_rule/", status=200, params={"url": "http://google.com"}
+            "/admin/allow_url/", status=200, params={"url": "http://google.com"}
         )
 
         assert response.content_type == "text/html"

--- a/tests/unit/checkmate/views/admin_test.py
+++ b/tests/unit/checkmate/views/admin_test.py
@@ -9,7 +9,7 @@ def test_admin_index(pyramid_request):
     response = index(pyramid_request)
 
     assert response == temporary_redirect_to(
-        pyramid_request.route_url("admin.allow_rule")
+        pyramid_request.route_url("admin.allow_url")
     )
 
 
@@ -19,7 +19,7 @@ def test_not_found_view(pyramid_request):
     assert response.status_code == 404
 
 
-class TestAdminAllowRuleViews:
+class TestAdminAllowURLViews:
     def test_get(self, views):
         response = views.get()
 


### PR DESCRIPTION
Fixes #919 

This one prettifies the admin page by using [bulma](https://github.com/jgthms/bulma) and streamlining the allow url navigation.