### PR TITLE
Add an admin page for blocking urls

### DIFF
--- a/checkmate/checker/url/__init__.py
+++ b/checkmate/checker/url/__init__.py
@@ -1,3 +1,3 @@
 from checkmate.checker.url.allow_rules import AllowRules
-from checkmate.checker.url.custom_rules import CustomRules
+from checkmate.checker.url.custom_rules import BlocklistParser, CustomRules
 from checkmate.checker.url.url_haus import URLHaus

--- a/checkmate/checker/url/custom_rules.py
+++ b/checkmate/checker/url/custom_rules.py
@@ -44,18 +44,18 @@ class CustomRules(HashedURLChecker):
         CustomRule.bulk_upsert(
             self._session,
             values=[
-                self._value_from_domain(domain, reason)
+                self.value_from_domain(domain, reason)
                 for domain, reason in raw_rules.items()
             ],
         )
 
     @staticmethod
-    def _value_from_domain(domain, reason):  # pragma: no cover
+    def value_from_domain(domain, reason):  # pragma: no cover
         if "*" in domain:
             # It's a wild card!
             domain = domain.lstrip("*")
             if "*" in domain:
-                raise ValueError("Cannot convert non prefix wildcard")
+                raise ValueError(f"Cannot convert non prefix wildcard: {domain!r}")
 
         # Using a raw domain as a URL is close enough, as it's subject
         # to normalisation anyway

--- a/checkmate/routes.py
+++ b/checkmate/routes.py
@@ -16,6 +16,7 @@ def add_routes(config):
 
     config.add_route("admin.index", "/admin/")
     config.add_route("admin.allow_url", "/admin/allow_url/")
+    config.add_route("admin.block_list", "/admin/block_list/")
 
     config.add_route("add_to_allow_list", "/api/rule", request_method="POST")
 

--- a/checkmate/services/__init__.py
+++ b/checkmate/services/__init__.py
@@ -1,3 +1,4 @@
+from checkmate.services.custom_rule import CustomRuleService
 from checkmate.services.rule import RuleService
 from checkmate.services.secure_link import SecureLinkService
 from checkmate.services.signature import SignatureService
@@ -17,4 +18,7 @@ def includeme(config):  # pragma: no cover
     )
     config.register_service_factory(
         "checkmate.services.rule.factory", iface=RuleService
+    )
+    config.register_service_factory(
+        "checkmate.services.custom_rule.factory", iface=CustomRuleService
     )

--- a/checkmate/services/custom_rule.py
+++ b/checkmate/services/custom_rule.py
@@ -1,0 +1,66 @@
+from sqlalchemy import select
+
+from checkmate.checker import url
+from checkmate.models import CustomRule, Reason
+
+
+class CustomRuleService:
+    def __init__(self, db):
+        self._db = db
+
+    def set_block_list(self, text: str) -> list[str]:
+        rules, errors = self._parse_text(text)
+        if not errors:
+            self._set_custom_rules(rules)
+        return errors
+
+    def get_block_list(self) -> str:
+        lines = [
+            self._render_line(rule)
+            for rule in self._db.execute(select(CustomRule).order_by(CustomRule.rule))
+            .scalars()
+            .all()
+        ]
+        return "\n".join(lines)
+
+    @staticmethod
+    def _render_line(rule: CustomRule) -> str:
+        reasons = ",".join(tag.value for tag in rule.reasons)
+        return f"{rule.rule} {reasons}"
+
+    def _set_custom_rules(self, rules: list[CustomRule]) -> None:
+        self._db.query(CustomRule).delete()
+        CustomRule.bulk_upsert(self._db, values=rules)
+
+    def _parse_text(self, text: str) -> tuple[list[CustomRule], list[str]]:
+        rules, errors = [], []
+        for line in text.split("\n"):
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+
+            try:
+                domain, reason = self._parse_line(line)
+            except ValueError as e:
+                errors.append(str(e))
+                continue
+
+            try:
+                rules.append(url.CustomRules.value_from_domain(domain, reason))
+            except ValueError as e:
+                errors.append(str(e))
+
+        return rules, errors
+
+    @staticmethod
+    def _parse_line(line: str) -> tuple[str, Reason] | None:
+        match = url.BlocklistParser.LINE_PATTERN.match(line)
+        if not match:
+            raise ValueError(f"Cannot parse blocklist line: {line!r}")
+
+        raw_rule, reason = match.group(1), match.group(2)
+        return raw_rule, Reason.parse(reason)
+
+
+def factory(_context, request):
+    return CustomRuleService(request.db)

--- a/checkmate/templates/admin/base.html.jinja2
+++ b/checkmate/templates/admin/base.html.jinja2
@@ -22,6 +22,8 @@
     <div class="navbar-start" style="flex-grow: 1; justify-content: center;">
       <a class="navbar-item"
          href="{{ request.route_url("admin.allow_url") }}">Allow URL</a>
+      <a class="navbar-item"
+         href="{{ request.route_url("admin.block_list") }}">Block List</a>
       <div class="navbar-end">
         <div class="navbar-item">
           <div class="buttons">

--- a/checkmate/templates/admin/block_list.html.jinja2
+++ b/checkmate/templates/admin/block_list.html.jinja2
@@ -1,0 +1,63 @@
+{% extends "checkmate:templates/admin/base.html.jinja2" %}
+{% block content %}
+
+  <section>
+    <div class="container">
+      {% if errors %}
+        <article class="message is-danger">
+          <div class="message-body">
+            {% for error in errors %}
+              <p>{{ error }}</p>
+            {% endfor %}
+          </div>
+        </article>
+      {% endif %}
+
+      {% if message %}
+        <article class="message">
+          <div class="message-body">
+            <p>{{ message }}</p>
+          </div>
+        </article>
+      {% endif %}
+    </div>
+  </section>
+
+  <section>
+    <div class="container">
+      <fieldset class="box mt-6">
+        <legend class="label has-text-centered">Update Block List</legend>
+        <form action="{{ request.route_url("admin.block_list") }}" method="POST">
+          <input type="hidden" name="csrf_token" value="{{ get_csrf_token() }}">
+
+          <div class="field is-horizontal">
+            <div class="field-label is-normal">
+              <label class="label">Block List</label>
+            </div>
+            <div class="field-body">
+              <div class="field">
+                <div class="control is-expanded">
+                  <textarea class="textarea" name="block-list" rows="20">{{ block_list }}</textarea>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="field is-horizontal">
+            <div class="field-label is-normal">
+              <label class="label"></label>
+            </div>
+            <div class="field-body">
+              <div class="field">
+                <div class="control is-expanded">
+                  <input type="submit" class="button is-info" value="Update">
+                </div>
+              </div>
+            </div>
+          </div>
+        </form>
+      </fieldset>
+    </div>
+  </section>
+
+{% endblock %}

--- a/checkmate/views/admin.py
+++ b/checkmate/views/admin.py
@@ -8,7 +8,7 @@ from pyramid.view import (
 
 from checkmate.exceptions import ResourceConflict
 from checkmate.security import Permissions
-from checkmate.services import RuleService
+from checkmate.services import CustomRuleService, RuleService
 
 
 @view_config(route_name="admin.index")
@@ -21,35 +21,63 @@ def notfound(_request):
     return HTTPNotFound()
 
 
+@forbidden_view_config(path_info="/admin/*")
+def logged_out(request):
+    return HTTPFound(location=request.route_url("pyramid_googleauth.login"))
+
+
 @view_defaults(
     route_name="admin.allow_url",
     renderer="checkmate:templates/admin/allow_url.html.jinja2",
+    permission=Permissions.ADMIN,
 )
 class AdminAllowRuleViews:
     def __init__(self, request):
-        self.request = request
+        self._request = request
+        self._rule_service: RuleService = request.find_service(RuleService)
 
-    @view_config(
-        request_method="GET",
-        permission=Permissions.ADMIN,
-    )
+    @view_config(request_method="GET")
     def get(self):
         return {}
 
-    @view_config(
-        request_method="POST",
-        permission=Permissions.ADMIN,
-    )
+    @view_config(request_method="POST")
     def post(self):
-        url = self.request.params.get("url")
+        url = self._request.params.get("url")
         if not url:
             return {"messages": [{"detail": "URL is required"}]}
         try:
-            allow_rule = self.request.find_service(RuleService).add_to_allow_list(url)
+            allow_rule = self._rule_service.add_to_allow_list(url)
         except ResourceConflict as e:
             return {"messages": e.messages}
         return {"allow_rule": allow_rule}
 
-    @forbidden_view_config()
-    def logged_out(self):
-        return HTTPFound(location=self.request.route_url("pyramid_googleauth.login"))
+
+@view_defaults(
+    route_name="admin.block_list",
+    renderer="checkmate:templates/admin/block_list.html.jinja2",
+    permission=Permissions.ADMIN,
+)
+class AdminBlockListViews:
+    def __init__(self, request):
+        self._request = request
+        self._custom_rule_service: CustomRuleService = request.find_service(
+            CustomRuleService
+        )
+
+    @view_config(request_method="GET")
+    def get(self):
+        block_list = self._custom_rule_service.get_block_list()
+        return {"block_list": block_list}
+
+    @view_config(request_method="POST")
+    def post(self):
+        block_list: str = self._request.POST["block-list"]
+        if not block_list:
+            return {"errors": ["Block List is required"]}
+
+        errors = self._custom_rule_service.set_block_list(block_list)
+        if errors:
+            return {"errors": errors, "block_list": block_list}
+
+        block_list = self._custom_rule_service.get_block_list()
+        return {"message": "Block List set successfully", "block_list": block_list}

--- a/tests/functional/checkmate/views/admin_test.py
+++ b/tests/functional/checkmate/views/admin_test.py
@@ -30,3 +30,31 @@ class TestAdminAllowURL:
 
         assert response.content_type == "text/html"
         assert "Allowed as google.com/" in response.text
+
+
+class TestAdminBlockList:
+    def test_if_youre_not_logged_in_it_redirects_to_the_login_page(
+        self, app, route_url
+    ):
+        response = app.get("/admin/block_list/")
+
+        assert response == temporary_redirect_to(route_url("pyramid_googleauth.login"))
+
+    @pytest.mark.usefixtures("logged_in")
+    def test_form_renders_correctly(self, app):
+        response = app.get("/admin/block_list/", status=200)
+
+        assert response.content_type == "text/html"
+
+    @pytest.mark.usefixtures("logged_in")
+    def test_post_form_submission(self, app):
+        block_list = "example.com/ other\nmalicious.com/ malicious"
+        response = app.post(
+            "/admin/block_list/",
+            status=200,
+            params={"block-list": block_list},
+        )
+
+        assert response.content_type == "text/html"
+        assert "Block List set successfully" in response.text
+        assert block_list in response.text

--- a/tests/unit/checkmate/services/custom_rule_test.py
+++ b/tests/unit/checkmate/services/custom_rule_test.py
@@ -1,0 +1,76 @@
+from unittest.mock import sentinel
+
+import pytest
+
+from checkmate.models import Reason
+from checkmate.services import CustomRuleService
+from checkmate.services.custom_rule import factory
+
+
+class TestCustomRuleService:
+    def test_it_can_set_block_list(self, custom_rule_service):
+        block_list = "example.com/ other"
+
+        errors = custom_rule_service.set_block_list(block_list)
+
+        assert errors == []
+        assert custom_rule_service.get_block_list() == block_list
+
+    def test_it_can_get_block_list(self, custom_rule_service):
+        assert custom_rule_service.get_block_list() == ""
+
+    def test_it_cannot_set_block_list_with_invalid_line(self, custom_rule_service):
+        block_list = "example.com/other"
+
+        errors = custom_rule_service.set_block_list(block_list)
+
+        assert errors == [f"Cannot parse blocklist line: '{block_list}'"]
+
+    def test_it_can_set_block_list_with_comments(self, custom_rule_service):
+        block_list = "# comment.com/ other"
+
+        errors = custom_rule_service.set_block_list(block_list)
+
+        assert errors == []
+        assert custom_rule_service.get_block_list() == ""
+
+    def test_it_cannot_set_block_list_with_wildcard(self, custom_rule_service):
+        block_list = "sub.*.example.com/ other"
+
+        errors = custom_rule_service.set_block_list(block_list)
+
+        assert errors == ["Cannot convert non prefix wildcard: 'sub.*.example.com/'"]
+
+    def test_it_can_set_block_list_with_unknown_reason(self, custom_rule_service):
+        block_list = "example.com/ unknown"
+
+        errors = custom_rule_service.set_block_list(block_list)
+
+        assert errors == []
+        assert (
+            custom_rule_service.get_block_list() == f"example.com/ {Reason.OTHER.value}"
+        )
+
+    def test_it_can_get_ordered_block_list(self, custom_rule_service):
+        block_list = "example2.com/ other\nexample1.com/ malicious"
+
+        custom_rule_service.set_block_list(block_list)
+
+        lines = block_list.split("\n")
+        assert custom_rule_service.get_block_list() == "\n".join(sorted(lines))
+
+    @pytest.fixture
+    def custom_rule_service(self, db_session):
+        return CustomRuleService(db_session)
+
+
+class TestFactory:
+    def test_it(self, pyramid_request, CustomRuleService):
+        result = factory(sentinel.context, pyramid_request)
+
+        assert result == CustomRuleService.return_value
+        CustomRuleService.assert_called_once_with(pyramid_request.db)
+
+    @pytest.fixture
+    def CustomRuleService(self, patch):
+        return patch("checkmate.services.custom_rule.CustomRuleService")

--- a/tests/unit/checkmate/views/admin_test.py
+++ b/tests/unit/checkmate/views/admin_test.py
@@ -1,7 +1,13 @@
 import pytest
 
 from checkmate.exceptions import ResourceConflict
-from checkmate.views.admin import AdminAllowRuleViews, index, notfound
+from checkmate.views.admin import (
+    AdminAllowRuleViews,
+    AdminBlockListViews,
+    index,
+    logged_out,
+    notfound,
+)
 from tests.unit.matchers import temporary_redirect_to
 
 
@@ -19,6 +25,15 @@ def test_not_found_view(pyramid_request):
     assert response.status_code == 404
 
 
+def test_logged_out_redirects_to_login(pyramid_request):
+    response = logged_out(pyramid_request)
+
+    assert response == temporary_redirect_to(
+        pyramid_request.route_url("pyramid_googleauth.login")
+    )
+
+
+@pytest.mark.usefixtures("rule_service")
 class TestAdminAllowURLViews:
     def test_get(self, views):
         response = views.get()
@@ -57,13 +72,59 @@ class TestAdminAllowURLViews:
         )
         assert response == {"messages": exception.messages}
 
-    def test_logged_out_redirects_to_login(self, pyramid_request, views):
-        response = views.logged_out()
-
-        assert response == temporary_redirect_to(
-            pyramid_request.route_url("pyramid_googleauth.login")
-        )
-
     @pytest.fixture()
     def views(self, pyramid_request):
         return AdminAllowRuleViews(pyramid_request)
+
+
+@pytest.mark.usefixtures("custom_rule_service")
+class TestAdminBlockListViews:
+    def test_get(self, views, custom_rule_service):
+        response = views.get()
+
+        assert response == {
+            "block_list": custom_rule_service.get_block_list.return_value
+        }
+
+    def test_post(self, pyramid_request, views, custom_rule_service):
+        block_list = "block-list"
+        pyramid_request.POST["block-list"] = block_list
+        custom_rule_service.set_block_list.return_value = []
+        custom_rule_service.get_block_list.return_value = block_list
+
+        response = views.post()
+
+        custom_rule_service.set_block_list.assert_called_once_with(
+            pyramid_request.POST["block-list"]
+        )
+        assert response == {
+            "message": "Block List set successfully",
+            "block_list": block_list,
+        }
+
+    def test_post_empty_block_list(self, pyramid_request, views, custom_rule_service):
+        pyramid_request.POST["block-list"] = ""
+
+        response = views.post()
+
+        custom_rule_service.set_block_list.assert_not_called()
+        assert response == {"errors": ["Block List is required"]}
+
+    def test_post_with_errors(self, pyramid_request, views, custom_rule_service):
+        block_list = "block-list"
+        pyramid_request.POST["block-list"] = block_list
+        custom_rule_service.set_block_list.return_value = ["error"]
+
+        response = views.post()
+
+        custom_rule_service.set_block_list.assert_called_once_with(
+            pyramid_request.POST["block-list"]
+        )
+        assert response == {
+            "errors": ["error"],
+            "block_list": block_list,
+        }
+
+    @pytest.fixture()
+    def views(self, pyramid_request):
+        return AdminBlockListViews(pyramid_request)

--- a/tests/unit/services.py
+++ b/tests/unit/services.py
@@ -2,7 +2,12 @@ from unittest import mock
 
 import pytest
 
-from checkmate.services import RuleService, SignatureService, URLCheckerService
+from checkmate.services import (
+    CustomRuleService,
+    RuleService,
+    SignatureService,
+    URLCheckerService,
+)
 from checkmate.services.secure_link import SecureLinkService
 
 
@@ -37,3 +42,8 @@ def url_checker_service(mock_service):
 @pytest.fixture
 def rule_service(mock_service):
     return mock_service(RuleService)
+
+
+@pytest.fixture
+def custom_rule_service(mock_service):
+    return mock_service(CustomRuleService)


### PR DESCRIPTION
Refs #921 

This PR addresses the first part, that is view and edit of block list.
Also for now it relies on the old helper code which will be removed in the subsequent PRs.
The form overwrites the current block list in the db with what has been entered so it deviates from the [upsert behavior](https://github.com/hypothesis/checkmate/blob/305da17b3bebc0c4bf9e514246a4e9060d3a3cd8/checkmate/checker/url/custom_rules.py#L44) we used to have to allow removal of the rules.

Testing
-------
1. Log in as devdata_admin (password: pass).
2. Go to `http://localhost:9099/admin/block_list`
3. Type in a sample block list and click the "Update" button to set the block list.
```
api.honeybadger/ other
canadacigarsupplies/ other
classicreload.com/ high-io
cmp.osano.com/ other
```
5. Confirm that the same block list is displayed after the form post.
6. Go to `http://localhost:9099/admin/block_list` to see persisted block list again.