### PR TITLE
Enable Sentry's "releases" feature

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ omit =
     checkmate/migrations/*
     checkmate/pshell.py
     checkmate/scripts/init_db.py
+    checkmate/_version.py
 
 [report]
 show_missing = True

--- a/checkmate/_version.py
+++ b/checkmate/_version.py
@@ -1,0 +1,71 @@
+import datetime
+import subprocess
+from subprocess import DEVNULL
+
+# git-archive substitution markers. When this file is written out by a `git
+# archive` command, these will be replaced by the short commit hash and the
+# commit date, respectively.
+VERSION_GIT_REF = "$Format:%h$"
+VERSION_GIT_DATE = "$Format:%ct$"
+
+# Fallback version in case we cannot derive the version.
+VERSION_UNKNOWN = "0+unknown"
+
+
+def fetch_git_ref():
+    return subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"],
+        stderr=DEVNULL,
+    ).strip()
+
+
+def fetch_git_date(ref):
+    output = subprocess.check_output(["git", "show", "-s", "--format=%ct", ref])
+    return datetime.datetime.fromtimestamp(int(output))
+
+
+def fetch_git_dirty():
+    # Ensure git index is up-to-date first. This usually isn't necessary, but
+    # can be needed inside a docker container where the index is out of date.
+    subprocess.call(["git", "update-index", "-q", "--refresh"])
+    dirty_tree = bool(subprocess.call(["git", "diff-files", "--quiet"]))
+    dirty_index = bool(
+        subprocess.call(["git", "diff-index", "--quiet", "--cached", "HEAD"])
+    )
+    return dirty_tree or dirty_index
+
+
+def git_version():
+    ref = fetch_git_ref()
+    date = fetch_git_date(ref)
+    dirty = fetch_git_dirty()
+    return pep440_version(date, ref, dirty)
+
+
+def git_archive_version():
+    ref = VERSION_GIT_REF
+    date = datetime.datetime.fromtimestamp(int(VERSION_GIT_DATE))
+    return pep440_version(date, ref)
+
+
+def pep440_version(date, ref, dirty=False):
+    """Build a PEP440-compliant version number from the passed information."""
+    return f"{date.strftime('%Y%m%d')}+g{ref}{'.dirty' if dirty else ''}"
+
+
+def get_version():  # pragma: no cover
+    """Fetch the current application version."""
+    # First we try to retrieve the current application version from git.
+    try:
+        return git_version()
+    except subprocess.CalledProcessError:
+        pass
+
+    # We are not in a git checkout or extracting the version from git failed,
+    # so we attempt to read a version written into the header of this file by
+    # `git archive`.
+    if not VERSION_GIT_REF.startswith("$"):
+        return git_archive_version()
+
+    # If neither of these strategies work, we fall back to VERSION_UNKNOWN.
+    return VERSION_UNKNOWN

--- a/checkmate/app.py
+++ b/checkmate/app.py
@@ -8,6 +8,7 @@ import pyramid.config
 import pyramid_tm
 from pyramid.session import SignedCookieSessionFactory
 
+from checkmate._version import get_version
 from checkmate.security import SecurityPolicy
 
 logger = logging.getLogger(__name__)
@@ -110,11 +111,20 @@ class CheckmateConfigurator:
         config.add_settings({"tm.manager_hook": pyramid_tm.explicit_manager})
 
     def _configure_sentry(self, config):
-        # Configure sentry
         config.add_settings(
             {
                 "h_pyramid_sentry.filters": [],
                 "h_pyramid_sentry.sqlalchemy_support": True,
+                # Enable Sentry's "Releases" feature, see:
+                # https://docs.sentry.io/platforms/python/configuration/options/#release
+                #
+                # h_pyramid_sentry passes any h_pyramid_sentry.init.* Pyramid settings
+                # through to sentry_sdk.init(), see:
+                # https://github.com/hypothesis/h-pyramid-sentry?tab=readme-ov-file#settings
+                #
+                # For the full list of options that sentry_sdk.init() supports see:
+                # https://docs.sentry.io/platforms/python/configuration/options/
+                "h_pyramid_sentry.init.release": get_version(),
             }
         )
         if self.celery_worker:


### PR DESCRIPTION
The releases feature is useful in itself, and this should also stop the
"discarded session update because of missing release" messages that
`sentry_sdk` is logging all the time.
