### PR TITLE
Replace httpretty with responses for urllib3 2.5.0 compatibility

### DIFF
--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -5,7 +5,7 @@
 #    pip-compile --allow-unsafe requirements/checkformatting.in
 #
 black==25.1.0
-    # via -r checkformatting.in
+    # via -r requirements/checkformatting.in
 build==1.0.3
     # via pip-tools
 click==8.1.7
@@ -15,7 +15,7 @@ click==8.1.7
 importlib-metadata==7.0.1
     # via pip-sync-faster
 isort==6.0.1
-    # via -r checkformatting.in
+    # via -r requirements/checkformatting.in
 mypy-extensions==1.0.0
     # via black
 packaging==23.2
@@ -25,10 +25,10 @@ packaging==23.2
 pathspec==0.12.1
     # via black
 pip-sync-faster==0.0.5
-    # via -r checkformatting.in
+    # via -r requirements/checkformatting.in
 pip-tools==7.4.1
     # via
-    #   -r checkformatting.in
+    #   -r requirements/checkformatting.in
     #   pip-sync-faster
 platformdirs==4.1.0
     # via black

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -5,7 +5,7 @@
 #    pip-compile --allow-unsafe requirements/format.in
 #
 black==25.1.0
-    # via -r format.in
+    # via -r requirements/format.in
 build==1.0.3
     # via pip-tools
 click==8.1.7
@@ -15,7 +15,7 @@ click==8.1.7
 importlib-metadata==7.0.1
     # via pip-sync-faster
 isort==6.0.1
-    # via -r format.in
+    # via -r requirements/format.in
 mypy-extensions==1.0.0
     # via black
 packaging==23.2
@@ -25,10 +25,10 @@ packaging==23.2
 pathspec==0.12.1
     # via black
 pip-sync-faster==0.0.5
-    # via -r format.in
+    # via -r requirements/format.in
 pip-tools==7.4.1
     # via
-    #   -r format.in
+    #   -r requirements/format.in
     #   pip-sync-faster
 platformdirs==4.1.0
     # via black

--- a/requirements/functests.in
+++ b/requirements/functests.in
@@ -1,6 +1,6 @@
 pip-tools
 pip-sync-faster
-httpretty
+responses
 pytest
 factory-boy
 webtest

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -84,8 +84,6 @@ h-pyramid-sentry==1.2.4
     # via -r requirements/requirements.txt
 h-testkit==1.0.1
     # via -r requirements/functests.in
-httpretty==1.1.4
-    # via -r requirements/functests.in
 hupper==1.12
     # via
     #   -r requirements/requirements.txt
@@ -227,6 +225,8 @@ python-dateutil==2.8.2
     #   -r requirements/requirements.txt
     #   celery
     #   faker
+pyyaml==6.0.2
+    # via responses
 referencing==0.32.1
     # via
     #   -r requirements/requirements.txt
@@ -237,10 +237,13 @@ requests==2.32.4
     #   -r requirements/requirements.txt
     #   checkmatelib
     #   requests-oauthlib
+    #   responses
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/requirements.txt
     #   google-auth-oauthlib
+responses==0.25.7
+    # via -r requirements/functests.in
 rpds-py==0.16.2
     # via
     #   -r requirements/requirements.txt
@@ -287,6 +290,7 @@ urllib3==2.2.2
     # via
     #   -r requirements/requirements.txt
     #   requests
+    #   responses
     #   sentry-sdk
 venusian==3.1.0
     # via

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -106,7 +106,6 @@ greenlet==3.0.3
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
-    #   sqlalchemy
 gunicorn==23.0.0
     # via
     #   -r requirements/requirements.txt
@@ -118,8 +117,6 @@ h-pyramid-sentry==1.2.4
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
 h-testkit==1.0.1
-    # via -r requirements/tests.txt
-httpretty==1.1.4
     # via -r requirements/tests.txt
 hupper==1.12
     # via
@@ -324,6 +321,10 @@ python-dateutil==2.8.2
     #   -r requirements/tests.txt
     #   celery
     #   faker
+pyyaml==6.0.2
+    # via
+    #   -r requirements/tests.txt
+    #   responses
 referencing==0.32.1
     # via
     #   -r requirements/requirements.txt
@@ -336,11 +337,14 @@ requests==2.32.4
     #   -r requirements/tests.txt
     #   checkmatelib
     #   requests-oauthlib
+    #   responses
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   google-auth-oauthlib
+responses==0.25.7
+    # via -r requirements/tests.txt
 rpds-py==0.16.2
     # via
     #   -r requirements/requirements.txt
@@ -403,6 +407,7 @@ urllib3==2.2.2
     #   -r requirements/requirements.txt
     #   -r requirements/tests.txt
     #   requests
+    #   responses
     #   sentry-sdk
 venusian==3.1.0
     # via

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,7 +1,7 @@
 pip-tools
 pip-sync-faster
 coverage
-httpretty
+responses
 pytest
 factory-boy
 webtest

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -86,8 +86,6 @@ h-pyramid-sentry==1.2.4
     # via -r requirements/requirements.txt
 h-testkit==1.0.1
     # via -r requirements/tests.in
-httpretty==1.1.4
-    # via -r requirements/tests.in
 hupper==1.12
     # via
     #   -r requirements/requirements.txt
@@ -229,6 +227,8 @@ python-dateutil==2.8.2
     #   -r requirements/requirements.txt
     #   celery
     #   faker
+pyyaml==6.0.2
+    # via responses
 referencing==0.32.1
     # via
     #   -r requirements/requirements.txt
@@ -239,10 +239,13 @@ requests==2.32.4
     #   -r requirements/requirements.txt
     #   checkmatelib
     #   requests-oauthlib
+    #   responses
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/requirements.txt
     #   google-auth-oauthlib
+responses==0.25.7
+    # via -r requirements/tests.in
 rpds-py==0.16.2
     # via
     #   -r requirements/requirements.txt
@@ -289,6 +292,7 @@ urllib3==2.2.2
     # via
     #   -r requirements/requirements.txt
     #   requests
+    #   responses
     #   sentry-sdk
 venusian==3.1.0
     # via

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@ import functools
 from os import environ
 from unittest import mock
 
-import httpretty
 import pytest
+import responses
 from pyramid.testing import DummyRequest, testConfig
 
 
@@ -23,19 +23,14 @@ def pyramid_settings():
 
 
 @pytest.fixture(autouse=True)
-def httpretty_():
-    """Monkey-patch Python's socket core module to mock all HTTP responses.
+def responses_():
+    """Mock all HTTP responses using responses library.
 
     We never want real HTTP requests to be sent by the tests so replace them
-    all with mock responses. This handles requests sent using the standard
-    urllib2 library and the third-party httplib2 and requests libraries.
+    all with mock responses. This handles requests sent using the requests library.
     """
-    httpretty.enable(allow_net_connect=False)
-
-    yield
-
-    httpretty.disable()
-    httpretty.reset()
+    with responses.RequestsMock() as rsps:
+        yield rsps
 
 
 @pytest.fixture

--- a/tests/unit/checkmate/checker/pipeline/web_test.py
+++ b/tests/unit/checkmate/checker/pipeline/web_test.py
@@ -1,9 +1,8 @@
 import os
 from unittest.mock import sentinel
 
-import httpretty
 import pytest
-from httpretty import httprettified
+import responses
 from requests.exceptions import HTTPError, ReadTimeout
 
 from checkmate.checker.pipeline import Download
@@ -11,10 +10,10 @@ from checkmate.exceptions import StageException, StageRetryableException
 
 
 class TestDownload:
-    @httprettified
+    @responses.activate
     def test_it_downloads_a_file(self, tmpdir):
         url = "https://example.com"
-        httpretty.register_uri(httpretty.GET, url, body="some content")
+        responses.add(responses.GET, url, body="some content")
 
         result = Download(url)(tmpdir)
 

--- a/tests/unit/checkmate/checker/url/url_haus_test.py
+++ b/tests/unit/checkmate/checker/url/url_haus_test.py
@@ -2,8 +2,8 @@ from unittest.mock import sentinel
 
 import importlib_resources
 import pytest
+import responses
 from h_matchers import Any
-from httpretty import httprettified, httpretty
 
 from checkmate.checker.url import URLHaus
 from checkmate.models import Reason
@@ -29,10 +29,10 @@ class TestURLHaus:
 
         assert response == Any.generator().containing([]).only()
 
-    @httprettified
+    @responses.activate
     def test_reinitialize_db(self, URLHausRule):
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             "https://urlhaus.abuse.ch/downloads/csv/",
             body=self.read_fixture("csv.txt.zip"),
         )
@@ -42,9 +42,10 @@ class TestURLHaus:
         URLHausRule.delete_all.assert_called_once_with(sentinel.db_session)
         self.assert_expected_sync(response, URLHausRule)
 
+    @responses.activate
     def test_partial_update(self, URLHausRule):
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             "https://urlhaus.abuse.ch/downloads/csv_recent/",
             body=self.read_fixture("csv.txt"),
         )


### PR DESCRIPTION
Replace httpretty with the responses library to resolve compatibility issues with urllib3 2.5.0. The httpretty library is no longer maintained and incompatible with the updated urllib3 version.

Changes:
- Update requirements files to use responses==0.25.7 instead of httpretty==1.1.4
- Migrate test files to use @responses.activate decorator instead of @httprettified
- Replace httpretty.register_uri() calls with responses.add()
- Update global test configuration to use responses.RequestsMock()

🤖 Generated with [Claude Code](https://claude.ai/code)

----

[Slack thread](https://hypothes-is.slack.com/archives/C1MA4E9B9/p1752145601891929?thread_ts=1736870406.669859&cid=C1MA4E9B9)