### PR TITLE
Don't log every allowed and blocked URL

### DIFF
--- a/checkmate/views/api/check_url.py
+++ b/checkmate/views/api/check_url.py
@@ -1,16 +1,12 @@
 """URL checking."""
 
-import logging
-
 from pyramid.httpexceptions import HTTPNoContent
 from pyramid.view import view_config
 
 from checkmate.exceptions import BadURL, BadURLParameter
-from checkmate.models import BlockedFor, Reason, Source
+from checkmate.models import BlockedFor, Reason
 from checkmate.security import Permissions
 from checkmate.services import SecureLinkService, URLCheckerService
-
-logger = logging.getLogger(__name__)
 
 
 @view_config(route_name="check_url", renderer="json", permission=Permissions.CHECK_URL)
@@ -49,9 +45,6 @@ def check_url(request):
 
     if not detections:
         # If everything is fine give a 204 which is successful, but has no body
-        logger.info(
-            "Access allowed for URL %r via source %s", url, Source.ALLOW_LIST.value
-        )
         return HTTPNoContent()
 
     # Get unique reasons mapped to corresponding detections
@@ -59,12 +52,6 @@ def check_url(request):
 
     # Reasons are ordered, worst first
     worst_reason = min(reasons)
-    logger.info(
-        "Access blocked for URL %r via source %s due to reason %s",
-        url,
-        reasons[worst_reason].source.value,
-        worst_reason.value,
-    )
 
     blocked_for = request.GET.get("blocked_for", BlockedFor.GENERAL.value)
 

--- a/tests/unit/checkmate/views/api/check_url_test.py
+++ b/tests/unit/checkmate/views/api/check_url_test.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 from checkmate.exceptions import BadURL, BadURLParameter
@@ -107,33 +105,3 @@ class TestURLCheck:
 
         with pytest.raises(BadURLParameter):
             check_url(pyramid_request)
-
-    def test_it_logs_allowed_url(self, pyramid_request, info_caplog):
-        url = "http://example.com"
-        pyramid_request.params["url"] = url
-        pyramid_request.params["allow_all"] = "1"
-
-        check_url(pyramid_request)
-
-        assert info_caplog.messages == [
-            f"Access allowed for URL {url!r} via source {Source.ALLOW_LIST.value}"
-        ]
-
-    def test_it_logs_blocked_url(
-        self, pyramid_request, info_caplog, url_checker_service
-    ):
-        url = "http://example.com"
-        pyramid_request.params["url"] = url
-        detection = Detection(Reason.MALICIOUS, Source.BLOCK_LIST)
-        url_checker_service.check_url.return_value = (detection,)
-
-        check_url(pyramid_request)
-
-        assert info_caplog.messages == [
-            f"Access blocked for URL {url!r} via source {detection.source.value} due to reason {detection.reason.value}"
-        ]
-
-    @pytest.fixture
-    def info_caplog(self, caplog):
-        caplog.set_level(logging.INFO)
-        return caplog


### PR DESCRIPTION
It's causing too much data usage in Sentry Logs. An alternative would be to filter these log messages out from Sentry (using Sentry's `before_send_log()` function) which would still allow the messages to be viewed in Elastic Beanstalk logs or CloudWatch.

This logging was added in https://github.com/hypothesis/checkmate/pull/944 back in January 2025, I don't remember why.