### PR TITLE
Add via decomission banner

### DIFF
--- a/checkmate/static/static/css/wrapper-style.css
+++ b/checkmate/static/static/css/wrapper-style.css
@@ -32,7 +32,7 @@ a:hover {
 /* Major page chunks */
 
 header {
-  padding: 40px 0 0 0;
+  padding: 60px 0 0 0;
 }
 
 article > p:first-child {
@@ -79,7 +79,6 @@ body.danger {
   }
   header {
     line-height: 1;
-    padding: 0;
     font-size: 36px;
   }
   h1 {

--- a/checkmate/templates/blocked_page.html.jinja2
+++ b/checkmate/templates/blocked_page.html.jinja2
@@ -101,7 +101,7 @@
             }
         </style>
         <div class="decommission-banner">
-          Access to Via is being restricted as of Monday, January 26th, 2026. You can find information <a href="#" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
+          Access to Via is being restricted as of Monday, February 2nd, 2026. You can find information <a href="https://web.hypothes.is/blog/changes-to-via-hypothesis-proxy-server-for-annotation/" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
       </div>
     {% endif %}
 

--- a/checkmate/templates/blocked_page.html.jinja2
+++ b/checkmate/templates/blocked_page.html.jinja2
@@ -87,6 +87,24 @@
         } %}
     {% endif %}
 
+    {% if annotated_with == 'Via' %}
+        <style>
+            .decommission-banner {
+                padding: 10px 15px;
+                background: #fceedb;
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                font-weight: bold;
+                border: 1px solid #fbc168;
+            }
+        </style>
+        <div class="decommission-banner">
+          Access to Via is being restricted as of Monday, January 26th, 2026. You can find information <a href="#" target="_blank">here</a>, and you can <a href="https://web.hypothes.is/get-help/" target="_blank">reach our team here</a>.
+      </div>
+    {% endif %}
+
     <!-- Block reason: {{ reason }} -->
     <header>
       <h1>{{ text.heading | safe }}</h1>


### PR DESCRIPTION
Add a banner in block page indicating via is going to be decommissioned in January 26.

<img width="1116" height="653" alt="image" src="https://github.com/user-attachments/assets/3d216d3d-ffe2-4c6e-b900-6737c2bd9c2b" />

### Todo

- [x] Add definitive blog post URL