### PR TITLE
chore(dependabot): weekly schedule + raise PR limit to 20 (Phase 5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
+    interval: weekly
+  open-pull-requests-limit: 20
 
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
+    interval: weekly
+  open-pull-requests-limit: 20
   ignore:
     # Only send PRs for patch versions of Python.
     - dependency-name: "python"


### PR DESCRIPTION
## What
Dependabot config tuning for vuln-remediation **Phase 5** (recurrence prevention):

- `schedule: weekly` (was monthly) — surface dependency updates faster.
- `open-pull-requests-limit: 20` on every ecosystem — the default **5** caps *version-update* PRs and queues direct-dep bumps.

## Why
Most overdue Vanta findings are slow-surfacing or capped direct-dep updates. This reduces SLA drift. (Pure-transitive CVEs still need the manual `resolutions`/`pip-compile` sweep — Dependabot can't auto-fix those.)

Opened as **draft**: review + merge when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)